### PR TITLE
feat(ui): update document title dynamically based on route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom'
+import { useEffect } from 'react'
 import { ThemeProvider } from './ThemeContext'
 import Header from './components/Header'
 import Footer from './components/Footer'
@@ -7,10 +8,28 @@ import History from './pages/History'
 import Files from './pages/Files'
 import Settings from './pages/Settings'
 
+function RouteTitle() {
+  const location = useLocation()
+
+  useEffect(() => {
+    const titles: Record<string, string> = {
+      '/': 'Transmute - Converter',
+      '/files': 'Transmute - Files',
+      '/history': 'Transmute - History',
+      '/settings': 'Transmute - Settings',
+    }
+
+    document.title = titles[location.pathname] || 'Transmute'
+  }, [location])
+
+  return null
+}
+
 function App() {
   return (
     <ThemeProvider>
       <Router>
+        <RouteTitle />
         <div className="flex flex-col h-screen overflow-hidden">
           <Header />
           <main className="flex-grow overflow-auto">


### PR DESCRIPTION
## Summary
Sets the HTML `<title>` dynamically based on the current active page route, so it no longer just says "Transmute" on every tab.
Closes #14
## Changes
- **`App.tsx`**: Added a `RouteTitle` component inside the React Router that uses `useLocation` to sync `document.title` to:
  - `"Transmute - Converter"` for `/`
  - `"Transmute - Files"` for `/files`
  - `"Transmute - History"` for `/history`
  - `"Transmute - Settings"` for `/settings`
  - Fallback to `"Transmute"` for anything else

