### PR TITLE
Fixes __all__ listing non-existent ImgArrayConverter #10

### DIFF
--- a/backend/converters/__init__.py
+++ b/backend/converters/__init__.py
@@ -4,4 +4,4 @@ from .pandas_convert import PandasConverter
 from .drawio_convert import DrawioConverter
 from .converter_interface import ConverterInterface
 
-__all__ = ["FFmpegConverter", "PillowConverter", "PandasConverter", "ImgArrayConverter", "ConverterInterface"]
+__all__ = ["FFmpegConverter", "PillowConverter", "PandasConverter", "DrawioConverter", "ConverterInterface"]


### PR DESCRIPTION
## What
Replaced `"ImgArrayConverter"` with `"DrawioConverter"` in the `__all__` list in [backend/converters/__init__.py](cci:7://file:///Users/parth/HomeFolder/temp/OpenContributions/transmute/backend/converters/__init__.py:0:0-0:0).

## Why
The `__all__` list referenced `ImgArrayConverter`, which does not exist. The correct class imported in the module is `DrawioConverter`.

Closes #10

## Testing
Verified that `ImgArrayConverter` does not appear anywhere else in the codebase. The `__all__` list now matches all actual imports in the file.

---

* [x] Tested locally
