### PR TITLE
Fix duplicate function names in conversions.py

### DIFF
--- a/backend/api/routes/conversions.py
+++ b/backend/api/routes/conversions.py
@@ -138,7 +138,7 @@ async def create_conversion(
         }
     }
 )
-def delete_conversion(
+def delete_all_conversions(
     conversion_db: ConversionDB = Depends(get_conversion_db),
     conversion_relations_db: ConversionRelationsDB = Depends(get_conversion_relations_db)
 ):
@@ -164,7 +164,7 @@ def delete_conversion(
         }
     }
 )
-def delete_conversion(
+def delete_single_conversion(
     conversion_id: str,
     conversion_db: ConversionDB = Depends(get_conversion_db),
     conversion_relations_db: ConversionRelationsDB = Depends(get_conversion_relations_db)


### PR DESCRIPTION
Fix duplicate function names as suggested in issue #40.

- Renamed first delete_conversion to delete_all_conversions
- Renamed second delete_conversion to delete_single_conversion