### PR TITLE
fix: rename duplicate delete_conversion function to delete_all_conversions

### DIFF
--- a/backend/api/routes/conversions.py
+++ b/backend/api/routes/conversions.py
@@ -138,7 +138,7 @@ async def create_conversion(
         }
     }
 )
-def delete_conversion(
+def delete_all_conversions(
     conversion_db: ConversionDB = Depends(get_conversion_db),
     conversion_relations_db: ConversionRelationsDB = Depends(get_conversion_relations_db)
 ):


### PR DESCRIPTION
## Summary
Fixes Issue #40: Fix duplicate function names in conversions.py

## Problem
- Two `delete_conversion` functions defined in conversions.py (lines 141 and 167)
- Python uses the last definition, so the first function (delete all conversions) was overwritten
- This caused /all endpoint to malfunction

## Fix
- Renamed first `delete_conversion` (line 141) to `delete_all_conversions`
- Kept second `delete_conversion` (line 167) for single deletion

## Testing
This PR has been tested locally.

Good day! Thank you for maintaining this project. I hope this fix helps. If there are any issues, please let me know.

Warmly,
Jah-yee