### PR TITLE
feat: Add confirmation dialog before destructive actions

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react'
+
+interface ConfirmDialogProps {
+  isOpen: boolean
+  title: string
+  message: string
+  confirmLabel: string
+  cancelLabel?: string
+  isDestructive?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  isOpen,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  isDestructive = true,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.focus()
+      const handleEscape = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') onCancel()
+      }
+      document.addEventListener('keydown', handleEscape)
+      return () => document.removeEventListener('keydown', handleEscape)
+    }
+  }, [isOpen, onCancel])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity"
+        onClick={onCancel}
+      />
+      
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="dialog-title"
+        aria-describedby="dialog-message"
+        className="relative bg-surface-light rounded-xl shadow-2xl p-6 max-w-md w-full mx-4 border border-surface-dark focus:outline-none"
+      >
+        {/* Icon */}
+        <div className="flex items-center gap-3 mb-4">
+          {isDestructive && (
+            <div className="flex-shrink-0 w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center">
+              <svg className="w-5 h-5 text-primary-light" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+          )}
+          <h2 id="dialog-title" className="text-xl font-semibold text-text">
+            {title}
+          </h2>
+        </div>
+
+        {/* Message */}
+        <p id="dialog-message" className="text-text-muted text-sm mb-6">
+          {message}
+        </p>
+
+        {/* Actions */}
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-text-muted hover:text-text bg-surface-dark hover:bg-surface-light rounded-lg transition duration-200 text-sm font-medium"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className={`px-4 py-2 rounded-lg transition duration-200 text-sm font-semibold shadow-md hover:shadow-lg ${
+              isDestructive
+                ? 'bg-primary/20 hover:bg-primary/40 text-primary-light'
+                : 'bg-success hover:bg-success-dark text-white'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { useTheme, type ThemeName } from '../ThemeContext'
+import { ConfirmDialog } from '../components/ConfirmDialog'
 
 interface Theme {
   value: string
@@ -53,6 +54,13 @@ function Settings() {
   const [error, setError] = useState<string | null>(null)
   const [clearConversionsStatus, setClearConversionsStatus] = useState<'idle' | 'clearing' | 'success' | 'error'>('idle')
   const [clearUploadsStatus, setClearUploadsStatus] = useState<'idle' | 'clearing' | 'success' | 'error'>('idle')
+  const [confirmDialog, setConfirmDialog] = useState<{
+    isOpen: boolean
+    title: string
+    message: string
+    confirmLabel: string
+    onConfirm: () => void
+  } | null>(null)
   const themeRef = useRef<HTMLDivElement>(null)
 
   // Load settings once on mount
@@ -99,31 +107,49 @@ function Settings() {
   }
 
   const handleClearConversions = () => {
-    setClearConversionsStatus('clearing')
-    fetch('/api/conversions/all', { method: 'DELETE' })
-      .then(r => {
-        if (!r.ok) throw new Error()
-        setClearConversionsStatus('success')
-        setTimeout(() => setClearConversionsStatus('idle'), 2000)
-      })
-      .catch(() => {
-        setClearConversionsStatus('error')
-        setTimeout(() => setClearConversionsStatus('idle'), 2000)
-      })
+    setConfirmDialog({
+      isOpen: true,
+      title: 'Clear Conversion History?',
+      message: 'You are about to clear conversion history and delete converted files. This action cannot be undone. Do you wish to proceed?',
+      confirmLabel: 'Yes, Clear History',
+      onConfirm: () => {
+        setConfirmDialog(null)
+        setClearConversionsStatus('clearing')
+        fetch('/api/conversions/all', { method: 'DELETE' })
+          .then(r => {
+            if (!r.ok) throw new Error()
+            setClearConversionsStatus('success')
+            setTimeout(() => setClearConversionsStatus('idle'), 2000)
+          })
+          .catch(() => {
+            setClearConversionsStatus('error')
+            setTimeout(() => setClearConversionsStatus('idle'), 2000)
+          })
+      },
+    })
   }
 
   const handleClearUploads = () => {
-    setClearUploadsStatus('clearing')
-    fetch('/api/files/all', { method: 'DELETE' })
-      .then(r => {
-        if (!r.ok) throw new Error()
-        setClearUploadsStatus('success')
-        setTimeout(() => setClearUploadsStatus('idle'), 2000)
-      })
-      .catch(() => {
-        setClearUploadsStatus('error')
-        setTimeout(() => setClearUploadsStatus('idle'), 2000)
-      })
+    setConfirmDialog({
+      isOpen: true,
+      title: 'Clear Uploaded Files?',
+      message: 'You are about to delete all uploaded files. This action cannot be undone. Do you wish to proceed?',
+      confirmLabel: 'Yes, Clear Files',
+      onConfirm: () => {
+        setConfirmDialog(null)
+        setClearUploadsStatus('clearing')
+        fetch('/api/files/all', { method: 'DELETE' })
+          .then(r => {
+            if (!r.ok) throw new Error()
+            setClearUploadsStatus('success')
+            setTimeout(() => setClearUploadsStatus('idle'), 2000)
+          })
+          .catch(() => {
+            setClearUploadsStatus('error')
+            setTimeout(() => setClearUploadsStatus('idle'), 2000)
+          })
+      },
+    })
   }
 
   if (!loaded) {
@@ -316,6 +342,19 @@ function Settings() {
         </div>
 
       </div>
+
+      {/* Confirmation Dialog */}
+      {confirmDialog && (
+        <ConfirmDialog
+          isOpen={confirmDialog.isOpen}
+          title={confirmDialog.title}
+          message={confirmDialog.message}
+          confirmLabel={confirmDialog.confirmLabel}
+          isDestructive={true}
+          onConfirm={confirmDialog.onConfirm}
+          onCancel={() => setConfirmDialog(null)}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Implements confirmation dialog before destructive actions (Clear History / Clear Files) as requested in #19.

## Changes
- Created reusable `ConfirmDialog` component with ARIA accessibility
- Added confirmation dialog to Settings page for destructive actions
- Red "Yes" button + normal "No" button using CSS variables
- Warning message: "You are about to [action], do you wish to proceed?"
- Delayed fetch API calls until user confirms

## Screenshots
![Confirm Dialog](https://via.placeholder.com/400x200?text=Confirm+Dialog+Preview)

## Testing
- [x] Tested Clear History button
- [x] Tested Clear Files button
- [x] Verified Cancel button works
- [x] Verified Confirm button triggers action
- [x] Verified Escape key cancels dialog

Closes #19