### PR TITLE
fix + feat: filename tooltip and download utility

### DIFF
--- a/frontend/src/components/FileListItem.tsx
+++ b/frontend/src/components/FileListItem.tsx
@@ -118,7 +118,7 @@ function FileListItem({
         </div>
 
         {/* Filename */}
-        <p className="text-sm font-medium text-text truncate">
+        <p className="text-sm font-medium text-text truncate" title={getDisplayFilename()}>
           {getDisplayFilename()}
         </p>
 

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -1,0 +1,33 @@
+/**
+ * Download utilities for handling blob downloads
+ */
+
+/**
+ * Trigger a browser download from a blob response
+ * @param blob - The blob to download
+ * @param filename - The filename for the download
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  window.URL.revokeObjectURL(url)
+}
+
+/**
+ * Download a file from a URL
+ * @param url - The URL to download from
+ * @param filename - The filename for the download
+ */
+export async function downloadFromUrl(url: string, filename: string): Promise<void> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Download failed: ${response.statusText}`)
+  }
+  const blob = await response.blob()
+  downloadBlob(blob, filename)
+}

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -3,9 +3,47 @@
  */
 
 /**
- * Trigger a browser download from a blob response
- * @param blob - The blob to download
- * @param filename - The filename for the download
+ * Extract filename from content-disposition header or fallback to default
+ */
+function extractFilename(response: Response, fallback: string): string {
+  const contentDisposition = response.headers.get('content-disposition')
+  if (contentDisposition) {
+    const match = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/)
+    if (match) {
+      return match[1].replace(/['"]/g, '')
+    }
+  }
+  return fallback
+}
+
+/**
+ * Download a file from fetch response
+ * @param response - The fetch Response object
+ * @param fallbackFilename - Fallback filename if not provided in headers
+ * @returns The downloaded filename
+ */
+export async function downloadFromResponse(response: Response, fallbackFilename: string = 'download'): Promise<string> {
+  if (!response.ok) {
+    throw new Error(`Download failed: ${response.statusText}`)
+  }
+  
+  const blob = await response.blob()
+  const filename = extractFilename(response, fallbackFilename)
+  
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  window.URL.revokeObjectURL(url)
+  
+  return filename
+}
+
+/**
+ * Trigger a browser download from a blob
  */
 export function downloadBlob(blob: Blob, filename: string): void {
   const url = window.URL.createObjectURL(blob)
@@ -16,18 +54,4 @@ export function downloadBlob(blob: Blob, filename: string): void {
   a.click()
   document.body.removeChild(a)
   window.URL.revokeObjectURL(url)
-}
-
-/**
- * Download a file from a URL
- * @param url - The URL to download from
- * @param filename - The filename for the download
- */
-export async function downloadFromUrl(url: string, filename: string): Promise<void> {
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`Download failed: ${response.statusText}`)
-  }
-  const blob = await response.blob()
-  downloadBlob(blob, filename)
 }


### PR DESCRIPTION
Combines both changes into a single PR as requested:

**Issue #35**: Add tooltip to truncated filenames by adding `title` attribute so users can see the full filename on hover.

**Issue #36**: Extract duplicate download helper into a shared utility (`utils/download.ts`) with:
- `downloadFromResponse()`: Downloads from a fetch Response object
- `downloadBlob()`: Downloads from a Blob object
