### PR TITLE
fix: add more format aliases to media_types.py (#34)

### DIFF
--- a/backend/core/media_types.py
+++ b/backend/core/media_types.py
@@ -5,4 +5,7 @@ media_type_aliases = {
     'yml': 'yaml',
     'alac': 'm4a',
     'aif': 'aiff',
+    'tif': 'tiff',
+    'htm': 'html',
+    'mpg': 'mpeg',
 }


### PR DESCRIPTION
## Summary

Add common format aliases to media_types.py:
- tif → tiff
- htm → html
- mpg → mpeg

## Changes

```python
media_type_aliases = {
    'jpg': 'jpeg',
    'yml': 'yaml',
    'alac': 'm4a',
    'aif': 'aiff',
    'tif': 'tiff',
    'htm': 'html',
    'mpg': 'mpeg',
}
```

Closes #34