### PR TITLE
Force LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.rtf -linguist-detectable
 *.ipynb -linguist-detectable
+*.sh text eol=lf


### PR DESCRIPTION
This PR adds a ".gitattributes" rule to enforce "LF" line endings for "*.sh" files.

Without this, Windows checkouts can convert shell scripts to "CRLF", which may break Linux containers with errors like:

'''
exec /app/entrypoint.sh: no such file or directory
 '''