### PR TITLE
feat: add IPv6/more flexible interface binding support

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -1,3 +1,4 @@
+import json
 from functools import lru_cache
 from pathlib import Path
 from pydantic import Field, field_validator
@@ -82,6 +83,7 @@ class Settings(BaseSettings):
     # Binding to all interfaces is required as this app should be reachable from
     # other machines besides just localhost
     host: str = "0.0.0.0"  # nosec B104
+    hosts: list[str] | None = None
     port: int = 3313
     api_server_url: str | None = None
 
@@ -96,6 +98,54 @@ class Settings(BaseSettings):
         if len(normalized) >= 2 and normalized[0] == normalized[-1] and normalized[0] in {'"', "'"}:
             normalized = normalized[1:-1].strip()
         return normalized
+
+    @field_validator("hosts", mode="before")
+    @classmethod
+    def _normalize_hosts_env(cls, value):
+        """Normalize host list from CSV or JSON array env forms."""
+        if value is None:
+            return None
+
+        if isinstance(value, str):
+            normalized = value.strip()
+            if not normalized:
+                return None
+
+            if normalized.startswith("["):
+                try:
+                    value = json.loads(normalized)
+                except json.JSONDecodeError as exc:
+                    raise ValueError("hosts must be a CSV string or JSON array of strings") from exc
+            else:
+                value = normalized.split(",")
+
+        if isinstance(value, tuple):
+            value = list(value)
+
+        if not isinstance(value, list):
+            raise ValueError("hosts must be a CSV string or JSON array of strings")
+
+        parsed_hosts: list[str] = []
+        for entry in value:
+            if not isinstance(entry, str):
+                raise ValueError("hosts entries must be strings")
+
+            host = entry.strip()
+            if len(host) >= 2 and host[0] == host[-1] and host[0] in {'"', "'"}:
+                host = host[1:-1].strip()
+
+            if host:
+                parsed_hosts.append(host)
+
+        return parsed_hosts or None
+
+    def resolved_bind_host(self) -> str | list[str]:
+        """Return the uvicorn host argument preserving legacy behavior by default."""
+        return self.hosts if self.hosts else self.host
+
+    def has_host_override_conflict(self) -> bool:
+        """True when host was explicitly set but hosts will take precedence."""
+        return bool(self.hosts) and "host" in self.model_fields_set
 
     def model_post_init(self, __context):
         """Compute derived paths after initialization."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+import logging
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
@@ -13,6 +14,8 @@ from background import (
     recover_running_jobs,
 )
 import uvicorn
+
+logger = logging.getLogger(__name__)
 
 
 def build_api_description(app_name: str) -> str:
@@ -115,9 +118,22 @@ def create_app() -> FastAPI:
     
     return app
 
+
+def run_api_server(app: FastAPI, settings) -> None:
+    if settings.has_host_override_conflict():
+        logger.warning("Both host and hosts are configured. Using hosts and ignoring host.")
+
+    uvicorn.run(
+        app,
+        host=settings.resolved_bind_host(),
+        port=settings.port,
+        log_config=build_logging_config(),
+    )
+
+
 if __name__ == "__main__":
     settings = get_settings()
     app = create_app()
     cleanup_thread = get_upload_cleanup_thread()
     cleanup_thread.start()
-    uvicorn.run(app, host=settings.host, port=settings.port, log_config=build_logging_config())
+    run_api_server(app, settings)

--- a/backend/tests/core/test_settings.py
+++ b/backend/tests/core/test_settings.py
@@ -10,6 +10,7 @@ def test_settings_defaults(tmp_path, monkeypatch):
         assert s.app_name == "Transmute"
         assert s.port == 3313
         assert s.host == "0.0.0.0"
+        assert s.hosts is None
         assert s.auth_algorithm == "HS256"
     finally:
         get_settings.cache_clear()
@@ -73,3 +74,44 @@ def test_get_settings_returns_same_instance():
         assert a is b
     finally:
         get_settings.cache_clear()
+
+
+def test_hosts_csv_string_is_normalized(tmp_path):
+    s = Settings(data_dir=tmp_path / "data", hosts=" :: , 0.0.0.0 ")
+    assert s.hosts == ["::", "0.0.0.0"]
+
+
+def test_hosts_json_array_string_is_normalized(tmp_path):
+    s = Settings(data_dir=tmp_path / "data", hosts='["::","0.0.0.0"]')
+    assert s.hosts == ["::", "0.0.0.0"]
+
+
+def test_resolved_bind_host_uses_legacy_host_by_default(tmp_path):
+    s = Settings(data_dir=tmp_path / "data")
+    assert s.resolved_bind_host() == "0.0.0.0"
+
+
+def test_resolved_bind_host_prefers_hosts_over_host(tmp_path):
+    s = Settings(
+        data_dir=tmp_path / "data",
+        host="127.0.0.1",
+        hosts="::,0.0.0.0",
+    )
+    assert s.resolved_bind_host() == ["::", "0.0.0.0"]
+
+
+def test_has_host_override_conflict_when_host_and_hosts_are_set(tmp_path):
+    s = Settings(
+        data_dir=tmp_path / "data",
+        host="127.0.0.1",
+        hosts="::,0.0.0.0",
+    )
+    assert s.has_host_override_conflict() is True
+
+
+def test_no_host_override_conflict_when_only_hosts_is_set(tmp_path):
+    s = Settings(
+        data_dir=tmp_path / "data",
+        hosts="::,0.0.0.0",
+    )
+    assert s.has_host_override_conflict() is False

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,45 @@
+import main as app_main
+
+
+class DummySettings:
+    def __init__(self, resolved_host, port=3313, has_conflict=False):
+        self.port = port
+        self._resolved_host = resolved_host
+        self._has_conflict = has_conflict
+
+    def resolved_bind_host(self):
+        return self._resolved_host
+
+    def has_host_override_conflict(self):
+        return self._has_conflict
+
+
+def test_run_api_server_uses_resolved_bind_host(monkeypatch):
+    captured = {}
+
+    def fake_run(app, host, port, log_config):
+        captured["app"] = app
+        captured["host"] = host
+        captured["port"] = port
+        captured["log_config"] = log_config
+
+    monkeypatch.setattr(app_main.uvicorn, "run", fake_run)
+    settings = DummySettings(["::", "0.0.0.0"], port=443)
+    app = object()
+
+    app_main.run_api_server(app, settings)
+
+    assert captured["app"] is app
+    assert captured["host"] == ["::", "0.0.0.0"]
+    assert captured["port"] == 443
+    assert isinstance(captured["log_config"], dict)
+
+
+def test_run_api_server_logs_warning_on_host_override(monkeypatch, caplog):
+    monkeypatch.setattr(app_main.uvicorn, "run", lambda *args, **kwargs: None)
+    settings = DummySettings(["::", "0.0.0.0"], has_conflict=True)
+
+    with caplog.at_level("WARNING"):
+        app_main.run_api_server(object(), settings)
+
+    assert "Both host and hosts are configured" in caplog.text

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -133,15 +133,17 @@ RUN rm -rf /app/backend/tests
 # Copy built frontend from builder stage
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 
-# Copy entrypoint script
-COPY docker/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+# Copy entrypoint script with executable permission
+COPY --chmod=755 docker/entrypoint.sh /app/entrypoint.sh
+
+# Ensure copied application files are always traversable/readable regardless of host umask.
+RUN chmod -R a+rX /app/backend /app/frontend
 
 # Expose port
 EXPOSE 3313
 
 # Start the application
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
 
 # Image metadata (OCI labels)
 ARG BUILD_DATE=""


### PR DESCRIPTION
## What
This PR modifies the way the uvicorn web server is set up to allow binding to an arbitrary set of interface addresses, both IPv6 and IPv4. (The reasons for this choice of implementation are explained in the next section.)

It also modifies the settings to add a new setting, "hosts" to perform these detailed bindings (configurable in the form of a comma-separated list or JSON array), falling back to the existing "host" setting if "hosts" is not present, and logging a warning if both are present. This was done to avoid breaking backwards compatibility for existing installations.

Unit tests were added to ensure these changes work correctly.

In the course of testing these changes, it was discovered that the Dockerfile does not build a working image (permissions errors abound) if the host and user on which the image is build uses a non-standard umask. The Dockerfile was hardened against this particular failure mode.

I have not updated the documentation in this repo, not finding any relevant changes to be made. I also haven't submitted a pull request to the web site repo to alter that documentation's environment variables section, although I can do so if desired.

## Why
Some networks and Kubernetes clusters, mine included, are IPv6-first clusters with IPv4 in a secondary or nonexistent role. This permits Transmute to be used in such situations.

The reason for the specific implementation chosen, allowing the specification of an arbitrary set of bindings, is rooted in a peculiarity of uvicorn; unlike most, configuring uvicorn to bind to "::" causes it to bind only to IPv6 addresses, and not to IPv4 addresses. As such, to make uvicorn bind to both IPv4 and IPv6 addresses requires specifying multiple bindings - "::,0.0.0.0" - or passing None rather than a string. Allowing specification of an arbitrary set of bindings seemed a more elegant solution than special-casing it.

## Testing
I tested the solution with the existing set of unit tests, with the new ones added for this situation, and finally by building a test Docker image which I ran locally in unconfigured-IPv4 mode, configured dual-stack mode, and finally IPv6-only mode, in each case executing file upload, conversion, and download to be sure of full functionality.

---

* [x] Tested locally
* [ ] Docs updated if needed
