### PR TITLE
fix: Update Dockerfile Calibre download URL to official download site

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,14 +97,14 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
     rm /tmp/drawio.deb && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Calibre from upstream GitHub releases to avoid stale distro packages.
+# Install Calibre from official download site to avoid stale distro packages.
 RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
     case "$ARCH" in \
       amd64) CALIBRE_ARCH="x86_64" ;; \
       arm64) CALIBRE_ARCH="arm64" ;; \
       *) echo "Unsupported architecture for calibre: $ARCH" >&2; exit 1 ;; \
     esac && \
-    CALIBRE_URL="https://github.com/kovidgoyal/calibre/releases/download/v${CALIBRE_VERSION}/calibre-${CALIBRE_VERSION}-${CALIBRE_ARCH}.txz" && \
+    CALIBRE_URL="https://download.calibre-ebook.com/${CALIBRE_VERSION}/calibre-${CALIBRE_VERSION}-${CALIBRE_ARCH}.txz" && \
     wget --tries=3 --waitretry=5 --retry-connrefused \
          "$CALIBRE_URL" -O /tmp/calibre.txz && \
     mkdir -p /opt/calibre && \


### PR DESCRIPTION
## What
Updates the Calibre binary download URL in `docker/Dockerfile` from the GitHub releases endpoint to the official Calibre download site (`download.calibre-ebook.com`).
The previous URL (`https://github.com/kovidgoyal/calibre/releases/download/...`) returned a 404 error because Calibre binaries are not distributed via GitHub releases. This caused Docker builds to fail with `wget` exit code 8.

## Why
Calibre binaries are hosted on `https://download.calibre-ebook.com`, not GitHub releases. The current Dockerfile cannot successfully build because the `wget` command fails to fetch the Calibre archive.

## Testing
- Verified that the new URL format matches the official Calibre download structure: `https://download.calibre-ebook.com/${VERSION}/calibre-${VERSION}-${ARCH}.txz`
- Tested locally