### PR TITLE
feat: add BASE_URL for subpath rooting

### DIFF
--- a/backend/api/routes/docs.py
+++ b/backend/api/routes/docs.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from core import get_settings
 from fastapi.openapi.docs import get_redoc_html
 
@@ -6,12 +6,14 @@ router = APIRouter(prefix="/docs", tags=["docs"], redirect_slashes=True)
 settings = get_settings()
 
 @router.get("", include_in_schema=False)
-def overridden_redoc():
+def overridden_redoc(request: Request):
     """
     Overrides the default /redoc endpoint to use a custom favicon.
     """
+    # Prefix absolute URLs with the sub-path the docs page is served from.
+    root_path = request.scope.get("root_path", "")
     return get_redoc_html(
-        openapi_url="/openapi.json",
+        openapi_url=f"{root_path}/openapi.json",
         title=f"{settings.app_name} API - ReDoc",
-        redoc_favicon_url="/icons/beaker-red-bg.png" # Replace with your custom favicon URL
+        redoc_favicon_url=f"{root_path}/icons/beaker-red-bg.png"
     )

--- a/backend/api/routes/oidc.py
+++ b/backend/api/routes/oidc.py
@@ -146,7 +146,9 @@ async def oidc_login(request: Request):
         # If no explicit app_url is set, we must assume the provider can reach us at the same URL we use to reach it.
         redirect_uri = str(request.url_for("oidc_callback"))
     else:
-        redirect_uri = settings.app_url.rstrip("/") + request.url_for("oidc_callback").path
+        # url_for already includes the sub-path (root_path), so combine it with
+        # app_url's origin only to avoid doubling the prefix under a sub-path.
+        redirect_uri = _origin(settings.app_url) + request.url_for("oidc_callback").path
     # Store a CSRF nonce in the session
     nonce = secrets.token_urlsafe(32)
     request.session["oidc_nonce"] = nonce
@@ -232,7 +234,9 @@ async def oidc_callback(
     _purge_expired_codes()
     _pending_codes[code] = (access_token, expires_in, time.monotonic() + _CODE_TTL_SECONDS)
 
-    return RedirectResponse(url=f"/?oidc_code={code}")
+    # Prefix the redirect with the sub-path so the browser lands on the app.
+    root_path = request.scope.get("root_path", "")
+    return RedirectResponse(url=f"{root_path}/?oidc_code={code}")
 
 
 class _OidcExchangeRequest(BaseModel):

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -1,6 +1,7 @@
 import json
 from functools import lru_cache
 from pathlib import Path
+from urllib.parse import urlparse
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -89,6 +90,9 @@ class Settings(BaseSettings):
     port: int = 3313
     api_server_url: str | None = None
 
+    # Reverse-proxy sub-path, derived from app_url's path (see model_post_init).
+    root_path: str = ""
+
     @field_validator("oidc_issuer_url", "oidc_internal_url", "app_url", "oidc_username_claim", mode="before")
     @classmethod
     def _normalize_url_env(cls, value: str) -> str:
@@ -162,6 +166,9 @@ class Settings(BaseSettings):
         self.tmp_dir = self.data_dir / "tmp"
 
         self.api_server_url = self.app_url if self.app_url else f"http://{self.host}:{self.port}"
+
+        # app_url=https://host/transmute -> "/transmute"; bare host -> "".
+        self.root_path = urlparse(self.app_url).path.rstrip("/") if self.app_url else ""
 
         # Ensure directories exist
         for path in [

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,9 @@
 from contextlib import asynccontextmanager
 import logging
+import re
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.openapi.utils import get_openapi
 from textwrap import dedent
 from api import router
@@ -16,6 +17,25 @@ from background import (
 import uvicorn
 
 logger = logging.getLogger(__name__)
+
+
+def render_index_html(raw_html: str, root_path: str) -> str:
+    """Inject the runtime sub-path into the SPA shell's <base> tag and
+    window.__BASE_PATH__ placeholder (both no-ops when root_path is empty)."""
+    base_href = f"{root_path}/" if root_path else "/"
+    html = re.sub(
+        r'<base\s+href="[^"]*"\s*/?>',
+        f'<base href="{base_href}" />',
+        raw_html,
+        count=1,
+    )
+    html = re.sub(
+        r'window\.__BASE_PATH__\s*=\s*"[^"]*"',
+        f'window.__BASE_PATH__ = "{root_path}"',
+        html,
+        count=1,
+    )
+    return html
 
 
 def build_api_description(app_name: str) -> str:
@@ -66,6 +86,11 @@ def create_app() -> FastAPI:
         docs_url=None,
         redoc_url=None,
         redirect_slashes=True,
+        # Fixes OpenAPI/docs/url_for URLs under a reverse-proxy sub-path ("" = root).
+        root_path=settings.root_path,
+        # We already advertise the full URL via `servers`, so skip the
+        # auto-added relative root_path entry to avoid a duplicate.
+        root_path_in_servers=False,
         lifespan=lifespan,
     )
 
@@ -107,7 +132,15 @@ def create_app() -> FastAPI:
     if web_dir.exists():
         app.mount("/assets", StaticFiles(directory=web_dir / "assets"), name="assets")
         app.mount("/icons", StaticFiles(directory=web_dir / "icons"), name="icons")
-        
+
+        # Template the SPA shell once with the runtime sub-path.
+        index_file = web_dir / "index.html"
+        index_html = (
+            render_index_html(index_file.read_text(encoding="utf-8"), settings.root_path)
+            if index_file.exists()
+            else None
+        )
+
         # Catch-all route for SPA - serves index.html for non-API routes
         @app.get("/{path:path}", include_in_schema=False)
         async def spa_fallback(request: Request, path: str):
@@ -115,11 +148,10 @@ def create_app() -> FastAPI:
             if requested_file.is_file() and requested_file.is_relative_to(web_dir.resolve()):
                 return FileResponse(requested_file)
 
-            index_file = web_dir / "index.html"
-            if index_file.exists():
-                return FileResponse(index_file)
+            if index_html is not None:
+                return HTMLResponse(index_html)
             raise HTTPException(status_code=404, detail="SPA index not found")
-    
+
     return app
 
 

--- a/backend/tests/api/test_oidc.py
+++ b/backend/tests/api/test_oidc.py
@@ -1,4 +1,56 @@
+from fastapi.testclient import TestClient
+
 from api.routes.oidc import _coerce_username_claim
+
+
+def _capture_redirect_uri(monkeypatch, tmp_path, app_url):
+    """Drive GET /api/oidc/login with OIDC configured and authlib mocked,
+    returning the redirect_uri the app would send to the provider."""
+    monkeypatch.setenv("APP_URL", app_url)
+    monkeypatch.setenv("OIDC_ISSUER_URL", "https://idp.example.com/realms/x")
+    monkeypatch.setenv("OIDC_CLIENT_ID", "transmute")
+    monkeypatch.setenv("OIDC_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    from core.settings import get_settings
+    get_settings.cache_clear()
+
+    import api.routes.oidc as oidc_mod
+    monkeypatch.setattr(oidc_mod, "_oauth", None)
+    monkeypatch.setattr(oidc_mod, "_metadata_cache", None)
+
+    async def fake_load_metadata():
+        return {"authorization_endpoint": "https://idp.example.com/realms/x/auth"}
+
+    monkeypatch.setattr(oidc_mod, "_load_metadata", fake_load_metadata)
+
+    captured = {}
+
+    async def fake_authorize_redirect(request, redirect_uri, **kwargs):
+        from starlette.responses import RedirectResponse
+        captured["redirect_uri"] = redirect_uri
+        return RedirectResponse(url="https://idp.example.com/auth")
+
+    oauth = oidc_mod._get_oauth()
+    monkeypatch.setattr(oauth.oidc, "authorize_redirect", fake_authorize_redirect)
+
+    import main
+    client = TestClient(main.create_app(), follow_redirects=False)
+    client.get("/api/oidc/login")
+    get_settings.cache_clear()
+    return captured["redirect_uri"]
+
+
+def test_oidc_redirect_uri_under_subpath(monkeypatch, tmp_path):
+    # Regression: url_for already includes the root_path, so combining it with
+    # app_url's full value used to double the sub-path (/transmute/transmute/...).
+    uri = _capture_redirect_uri(monkeypatch, tmp_path, "https://example.com/transmute")
+    assert uri == "https://example.com/transmute/api/oidc/callback"
+
+
+def test_oidc_redirect_uri_at_root(monkeypatch, tmp_path):
+    uri = _capture_redirect_uri(monkeypatch, tmp_path, "https://example.com")
+    assert uri == "https://example.com/api/oidc/callback"
 
 
 def test_coerce_username_claim_normalizes_supported_values():

--- a/backend/tests/core/test_settings.py
+++ b/backend/tests/core/test_settings.py
@@ -52,6 +52,26 @@ def test_api_server_url_from_app_url(tmp_path):
     assert s.api_server_url == "https://example.com"
 
 
+def test_root_path_empty_by_default(tmp_path):
+    s = Settings(data_dir=tmp_path / "data")
+    assert s.root_path == ""
+
+
+def test_root_path_empty_for_bare_host_app_url(tmp_path):
+    s = Settings(data_dir=tmp_path / "data", app_url="https://example.com")
+    assert s.root_path == ""
+
+
+def test_root_path_derived_from_app_url_subpath(tmp_path):
+    s = Settings(data_dir=tmp_path / "data", app_url="https://example.com/transmute")
+    assert s.root_path == "/transmute"
+
+
+def test_root_path_strips_trailing_slash(tmp_path):
+    s = Settings(data_dir=tmp_path / "data", app_url="https://example.com/transmute/")
+    assert s.root_path == "/transmute"
+
+
 def test_quoted_url_settings_are_normalized(tmp_path):
     s = Settings(
         data_dir=tmp_path / "data",

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -43,3 +43,26 @@ def test_run_api_server_logs_warning_on_host_override(monkeypatch, caplog):
         app_main.run_api_server(object(), settings)
 
     assert "Both host and hosts are configured" in caplog.text
+
+
+INDEX_HTML = (
+    '<head>\n'
+    '    <base href="/" />\n'
+    '    <script>window.__BASE_PATH__ = "";</script>\n'
+    '    <link rel="manifest" href="site.webmanifest" />\n'
+    '</head>\n'
+)
+
+
+def test_render_index_html_noop_at_root():
+    out = app_main.render_index_html(INDEX_HTML, "")
+    assert '<base href="/" />' in out
+    assert 'window.__BASE_PATH__ = ""' in out
+
+
+def test_render_index_html_injects_subpath():
+    out = app_main.render_index_html(INDEX_HTML, "/transmute")
+    assert '<base href="/transmute/" />' in out
+    assert 'window.__BASE_PATH__ = "/transmute"' in out
+    # Relative asset references are left untouched (resolved via <base> tag).
+    assert 'href="site.webmanifest"' in out

--- a/docker-compose-oidc-test.yml
+++ b/docker-compose-oidc-test.yml
@@ -1,0 +1,58 @@
+# Local sandbox to try the OIDC login flow with Transmute served under a
+# sub-path (/transmute). NOT for production.
+#
+#   docker compose -f docker-compose-oidc-test.yml up
+#
+# Then open http://localhost:3313/transmute/ and sign in with:
+#   username: testuser   password: password
+#
+# Keycloak admin console: http://localhost:8080/  (admin / admin)
+#
+# The browser reaches Keycloak at localhost:8080 while Transmute reaches it at
+# keycloak:8080 inside the Docker network; OIDC_INTERNAL_URL handles that split.
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    command: ["start-dev", "--import-realm"]
+    environment:
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+      - KC_HTTP_ENABLED=true
+      # Pin the issuer so tokens always say localhost:8080 regardless of which
+      # host requested them (browser uses localhost, backend uses keycloak).
+      # Without this, Keycloak derives the issuer from the request host and the
+      # token's `iss` claim fails validation against the discovery document.
+      - KC_HOSTNAME=http://localhost:8080
+      - KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true
+      - KC_HOSTNAME_STRICT=false
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./docker/keycloak/transmute-realm.json:/opt/keycloak/data/import/transmute-realm.json:ro
+
+  transmute:
+    container_name: transmute-dev
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    depends_on:
+      - keycloak
+    environment:
+      # Served under /transmute (the sub-path is derived from APP_URL).
+      - APP_URL=http://localhost:3313/transmute
+      # OIDC: browser-facing issuer vs backend-to-Keycloak internal URL.
+      - OIDC_ISSUER_URL=http://localhost:8080/realms/transmute
+      - OIDC_INTERNAL_URL=http://keycloak:8080/realms/transmute
+      - OIDC_CLIENT_ID=transmute
+      - OIDC_CLIENT_SECRET=transmute-secret
+      - OIDC_DISPLAY_NAME=Keycloak
+      - OIDC_USERNAME_CLAIM=preferred_username
+      - OIDC_AUTO_CREATE_USERS=true
+      - OIDC_AUTO_LAUNCH=false
+    ports:
+      - "3313:3313"
+    volumes:
+      - transmute_oidc_data:/app/data
+
+volumes:
+  transmute_oidc_data:

--- a/docker/keycloak/transmute-realm.json
+++ b/docker/keycloak/transmute-realm.json
@@ -1,0 +1,34 @@
+{
+  "realm": "transmute",
+  "enabled": true,
+  "sslRequired": "none",
+  "clients": [
+    {
+      "clientId": "transmute",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "transmute-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": [
+        "http://localhost:3313/transmute/*",
+        "http://localhost:3313/*"
+      ],
+      "webOrigins": ["*"]
+    }
+  ],
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "email": "testuser@example.com",
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "credentials": [
+        { "type": "password", "value": "password", "temporary": false }
+      ]
+    }
+  ]
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,10 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" id="favicon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <!-- Sub-path support: both rewritten at runtime by the backend (no-op at root). -->
+    <base href="/" />
+    <script>window.__BASE_PATH__ = "";</script>
+    <link rel="icon" id="favicon" type="image/png" sizes="32x32" href="icons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="icons/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon.png" />
+    <link rel="manifest" href="site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="Transmute" />

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,28 +1,27 @@
 {
-  "id": "/",
   "name": "Transmute",
   "short_name": "Transmute",
   "description": "Self-hosted, open-source file converter",
-  "start_url": "/",
+  "start_url": "./",
   "icons": [
     {
-      "src": "/icons/icon-192.png",
+      "src": "icons/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icons/icon-192-maskable.png",
+      "src": "icons/icon-192-maskable.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/icons/icon-512.png",
+      "src": "icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     },
     {
-      "src": "/icons/icon-512-maskable.png",
+      "src": "icons/icon-512-maskable.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { AuthProvider, useAuth } from './AuthContext'
 import { ThemeProvider, useTheme } from './ThemeContext'
 import Header from './components/Header'
 import Footer from './components/Footer'
+import { api } from './utils/api'
 
 const Account = lazy(() => import('./pages/Account'))
 const Auth = lazy(() => import('./pages/Auth'))
@@ -139,7 +140,7 @@ function App() {
   return (
     <AuthProvider>
       <ThemeProvider>
-        <Router>
+        <Router basename={api.basePath || undefined}>
           <RouteTitle />
           <AppShell />
         </Router>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { FaGithub, FaExternalLinkAlt, FaBook } from 'react-icons/fa'
 import { useTranslation } from 'react-i18next'
-import { publicFetch as fetch } from '../utils/api'
+import { api, publicFetch as fetch } from '../utils/api'
 
 const RELEASE_VERSION_PATTERN = /^v\d+\.\d+\.\d+$/
 const COMMIT_SHA_PATTERN = /^[0-9a-f]{7}$/i
@@ -137,7 +137,7 @@ function Footer() {
               </>
             )}
             <span className="text-text-muted/30">|</span>
-            <a href="/api/docs" className="hover:text-text transition-colors" aria-label={t('footer.apiDocs')} title={t('footer.apiDocs')}>
+            <a href={api.url('/api/docs')} className="hover:text-text transition-colors" aria-label={t('footer.apiDocs')} title={t('footer.apiDocs')}>
               <FaBook size={14} />
             </a>
             <span className="text-text-muted/30">|</span>

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { FaKey, FaUserPlus, FaArrowUpRightFromSquare } from 'react-icons/fa6'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../AuthContext'
-import { apiJson } from '../utils/api'
+import { api, apiJson } from '../utils/api'
 import PasswordField from '../components/PasswordField'
 
 interface OidcConfig {
@@ -45,7 +45,7 @@ function Auth() {
 
   useEffect(() => {
     if (oidcConfig?.auto_launch && oidcConfig.enabled && !requiresSetup && !suppressAutoLaunch) {
-      window.location.href = '/api/oidc/login'
+      window.location.href = api.url('/api/oidc/login')
     }
   }, [oidcConfig, requiresSetup, suppressAutoLaunch])
 
@@ -118,7 +118,7 @@ function Auth() {
               )}
 
               <a
-                href="/api/oidc/login"
+                href={api.url('/api/oidc/login')}
                 className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary px-5 py-3.5 font-semibold text-white transition hover:bg-primary-dark"
               >
                 <FaArrowUpRightFromSquare size={14} />
@@ -250,7 +250,7 @@ function Auth() {
                   <div className={`mt-4 flex gap-3 ${oidcConfig?.enabled && oidcConfig?.allow_unauthenticated ? 'flex-row' : 'flex-col'}`}>
                     {oidcConfig?.enabled && (
                       <a
-                        href="/api/oidc/login"
+                        href={api.url('/api/oidc/login')}
                         className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-white/10 bg-surface-light/70 px-5 py-3.5 font-semibold text-text transition hover:border-primary/40 hover:bg-surface-light"
                       >
                         <FaArrowUpRightFromSquare size={14} />

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,6 +1,13 @@
 const AUTH_TOKEN_KEY = 'transmute-access-token'
 export const AUTH_EXPIRED_EVENT = 'transmute:auth-expired'
 
+declare global {
+  interface Window {
+    // Injected into index.html at runtime by the backend; "" at the domain root.
+    __BASE_PATH__?: string
+  }
+}
+
 export class ApiError extends Error {
   status: number
   detail: string
@@ -70,44 +77,73 @@ async function buildApiError(response: Response) {
   return new ApiError(response.status, getErrorDetail(payload, response.statusText || 'Request failed'))
 }
 
-export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) {
-  const shouldUseAuth = options.auth !== false
-  const headers = new Headers(init.headers)
+/**
+ * HTTP client for the backend API. Prefixes every absolute ("/...") path with
+ * the reverse-proxy sub-path, attaches the bearer token, and surfaces ApiError
+ * on non-2xx responses for the json/blob/text helpers.
+ */
+export class ApiClient {
+  /** Normalized sub-path with no trailing slash ("" at the domain root). */
+  readonly basePath: string
 
-  if (shouldUseAuth) {
-    const token = getStoredToken()
-    if (token && !headers.has('Authorization')) {
-      headers.set('Authorization', `Bearer ${token}`)
+  constructor(basePath: string = window.__BASE_PATH__ ?? '') {
+    this.basePath = basePath.replace(/\/+$/, '')
+  }
+
+  /** Prefix an absolute ("/...") path with the sub-path; other inputs pass through. */
+  url(path: string): string {
+    return path.startsWith('/') ? `${this.basePath}${path}` : path
+  }
+
+  async fetch(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) {
+    if (typeof input === 'string') input = this.url(input)
+
+    const shouldUseAuth = options.auth !== false
+    const headers = new Headers(init.headers)
+
+    if (shouldUseAuth) {
+      const token = getStoredToken()
+      if (token && !headers.has('Authorization')) {
+        headers.set('Authorization', `Bearer ${token}`)
+      }
     }
+
+    const response = await window.fetch(input, { ...init, headers })
+
+    if (response.status === 401 && shouldUseAuth && getStoredToken()) {
+      window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT))
+    }
+
+    return response
   }
 
-  const response = await fetch(input, { ...init, headers })
-
-  if (response.status === 401 && shouldUseAuth && getStoredToken()) {
-    window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT))
+  async json<T>(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) {
+    const response = await this.fetch(input, init, options)
+    if (!response.ok) throw await buildApiError(response)
+    if (response.status === 204) return undefined as T
+    return response.json() as Promise<T>
   }
 
-  return response
+  async blob(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) {
+    const response = await this.fetch(input, init, options)
+    if (!response.ok) throw await buildApiError(response)
+    return response.blob()
+  }
+
+  async text(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) {
+    const response = await this.fetch(input, init, options)
+    if (!response.ok) throw await buildApiError(response)
+    return response.text()
+  }
 }
 
-export const authFetch = (input: RequestInfo | URL, init: RequestInit = {}) => apiFetch(input, init, { auth: true })
-export const publicFetch = (input: RequestInfo | URL, init: RequestInit = {}) => apiFetch(input, init, { auth: false })
+/** Shared client configured from the runtime sub-path. */
+export const api = new ApiClient()
 
-export async function apiJson<T>(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) {
-  const response = await apiFetch(input, init, options)
-  if (!response.ok) throw await buildApiError(response)
-  if (response.status === 204) return undefined as T
-  return response.json() as Promise<T>
-}
-
-export async function apiBlob(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) {
-  const response = await apiFetch(input, init, options)
-  if (!response.ok) throw await buildApiError(response)
-  return response.blob()
-}
-
-export async function apiText(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) {
-  const response = await apiFetch(input, init, options)
-  if (!response.ok) throw await buildApiError(response)
-  return response.text()
-}
+// Backward-compatible function exports delegating to the shared client.
+export const apiFetch = (input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) => api.fetch(input, init, options)
+export const authFetch = (input: RequestInfo | URL, init: RequestInit = {}) => api.fetch(input, init, { auth: true })
+export const publicFetch = (input: RequestInfo | URL, init: RequestInit = {}) => api.fetch(input, init, { auth: false })
+export const apiJson = <T,>(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) => api.json<T>(input, init, options)
+export const apiBlob = (input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) => api.blob(input, init, options)
+export const apiText = (input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) => api.text(input, init, options)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // Relative asset URLs so the app can be served under a runtime sub-path
+  // (resolved via the <base> tag injected by the backend). See index.html.
+  base: './',
   plugins: [react()],
   build: {
     outDir: 'dist',

--- a/k8s-deployment.yml
+++ b/k8s-deployment.yml
@@ -70,6 +70,11 @@ spec:
             # The value of APP_URL should be configured to match the host setting in the Ingress (below).
             # If your ingress provider is providing SSL into the cluster, you should prefix this URL
             # with "https" even though Transmute itself is not providing SSL.
+            #
+            # To serve Transmute under a sub-path instead of a dedicated host, include the path here
+            # (e.g. "https://your-domain.example/transmute"). Transmute serves itself under that
+            # sub-path, so the Ingress just routes the path as-is; do NOT strip the prefix. You would
+            # also change the Ingress "path" below from "/" to "/transmute".
             - name: APP_URL
               value: "https://transmute.your-domain.example"
           ports:


### PR DESCRIPTION
## What
Adds support for serving Transmute under a reverse-proxy **sub-path** (e.g.
`https://example.com/transmute/`), configured via the existing `APP_URL`, the
sub-path is derived from its path component (`https://host/transmute` →
`/transmute`; bare host → `/`, unchanged).

Refer to #174

The app serves the whole stack (frontend, API, docs) under the sub-path itself,
so the proxy just forwards the path as-is (no prefix stripping).

- Backend: `root_path` derived from `APP_URL` → `FastAPI(root_path=...)`; SPA
  shell templated at runtime to inject `<base href>` + `window.__BASE_PATH__`.
- Frontend: relative Vite base, `ApiClient` for the API base path, React Router
  `basename`.
- OIDC: fixed `redirect_uri` that doubled the sub-path.

## Why
Closes #174. Enables sub-path routing for setups where a dedicated
subdomain/DNS record isn't possible or wanted.

## Testing
- Added backend tests (`root_path` derivation, shell templating, OIDC
  `redirect_uri` regression); `make test-backend` / `make test-frontend` green.
- Verified the built image under `/transmute`: direct access, behind nginx, and
  a full OIDC login against Keycloak. Root deployment (`APP_URL` unset) unchanged.

---

* [x] Tested locally
* [x] Docs updated if needed

---

If this looks good @chase-roohms, I'd be happy to also update the docs site
(transmute-app.github.io) to cover sub-path deployment, let me know.
