### PR TITLE
feat: add MP3 to M4B conversion support (#210)

### DIFF
--- a/backend/converters/ffmpeg_convert.py
+++ b/backend/converters/ffmpeg_convert.py
@@ -60,11 +60,12 @@ class FFmpegConverter(ConverterInterface):
         'mka',
         'oma',
         'aa3',
+        'm4b', #issue (#210)
     }
     formats_with_qualities = {
         'mp4', 'avi', 'mov', 'mkv', 'webm', 'ts', '3gp', 'ogv', 'f4v',
         'm4v', 'flv', 'mpeg', 'wmv', 'asf',
-        'mp3', 'aac', 'wma', 'm4a', 'opus', 'mp2', 'ac3', 'oga',
+        'mp3', 'aac', 'wma', 'm4a', 'opus', 'mp2', 'ac3', 'oga', 'm4b',
     }
     supported_input_formats: set = video_formats | audio_formats
     supported_output_formats: set = (video_formats | audio_formats) - _decode_only_formats
@@ -355,7 +356,7 @@ class FFmpegConverter(ConverterInterface):
                 cmd.extend(['-q:v', '9'])
 
         # Quality settings for lossy audio formats via bitrate
-        _quality_audio_formats = {'mp3', 'aac', 'wma', 'm4a', 'opus', 'mp2', 'ac3', 'oga'}
+        _quality_audio_formats = {'mp3', 'aac', 'wma', 'm4a', 'opus', 'mp2', 'ac3', 'oga', 'm4b'}
         if quality and self.output_type in _quality_audio_formats:
             if self.output_type == 'ac3':
                 bitrates = {'high': '448k', 'medium': '256k', 'low': '128k'}


### PR DESCRIPTION
## What
Adds support for converting MP3 to M4B in the FFmpeg converter.

## Why
Closes #210. M4B is the standard audiobook format, and Transmute didn't previously support converting MP3 files to it. The fix is a minor addition to `backend/converters/ffmpeg_convert.py`, adding `m4b` to the existing format/quality sets that already handle similar MPEG-4 audio containers like `m4a`.

## Changes
- Added `'m4b'` to `audio_formats` (so it's recognized as a valid output format and gets `-vn` applied to strip any video stream)
- Added `'m4b'` to `formats_with_qualities` (so quality presets are exposed for it, same as `m4a`)
- Added `'m4b'` to `_quality_audio_formats` inside `convert()` (so the high/medium/low bitrate settings actually apply to M4B output)

No other code paths needed changes — M4B uses the same AAC encoding path as M4A, and FFmpeg correctly infers the `ipod` (MPEG-4 audio) muxer from the `.m4b` extension automatically, with no extra format flags required.

## Testing
Verified the conversion manually with FFmpeg directly:
* [x] Tested locally
* [ ] Docs updated if needed
