### PR TITLE
feat: add custom CSS support for PDF conversion

### DIFF
--- a/backend/assets/default-pdf.css
+++ b/backend/assets/default-pdf.css
@@ -1,0 +1,111 @@
+/* Default compact stylesheet for PDF output (used by pypandoc converter).
+ *
+ * This addresses the common complaint that the default pandoc/weasyprint
+ * output has overly large fonts and margins, producing unnecessarily
+ * multi-page PDFs.  Administrators can override this file entirely by
+ * setting the PDF_CUSTOM_CSS_PATH environment variable to point at a
+ * custom .css file on the server.
+ */
+
+@page {
+    margin: 1.5cm 1.8cm;
+    size: A4;
+}
+
+html {
+    font-size: 11pt;
+    line-height: 1.4;
+}
+
+body {
+    font-family: "Helvetica Neue", Helvetica, Arial, "Liberation Sans", sans-serif;
+    margin: 0;
+    padding: 0;
+    color: #1a1a1a;
+}
+
+/* Headings */
+h1 { font-size: 1.6rem; margin-top: 1.2em; margin-bottom: 0.4em; }
+h2 { font-size: 1.35rem; margin-top: 1em; margin-bottom: 0.3em; }
+h3 { font-size: 1.15rem; margin-top: 0.8em; margin-bottom: 0.2em; }
+h4 { font-size: 1rem; margin-top: 0.6em; margin-bottom: 0.2em; }
+h5, h6 { font-size: 0.9rem; margin-top: 0.5em; margin-bottom: 0.2em; }
+
+/* Paragraphs */
+p { margin-top: 0.3em; margin-bottom: 0.5em; }
+
+/* Lists */
+ul, ol { margin-top: 0.3em; margin-bottom: 0.5em; padding-left: 1.5em; }
+li { margin-bottom: 0.15em; }
+
+/* Code */
+code {
+    font-family: "Courier New", Courier, "Liberation Mono", monospace;
+    font-size: 0.85em;
+    background-color: #f5f5f5;
+    padding: 0.1em 0.25em;
+    border-radius: 2px;
+}
+
+pre {
+    background-color: #f5f5f5;
+    padding: 0.6em 0.8em;
+    border-radius: 3px;
+    overflow-x: auto;
+    font-size: 0.82em;
+    line-height: 1.3;
+    margin-top: 0.4em;
+    margin-bottom: 0.6em;
+}
+
+pre code {
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
+}
+
+/* Blockquotes */
+blockquote {
+    margin: 0.5em 0;
+    padding-left: 1em;
+    border-left: 3px solid #ccc;
+    color: #555;
+}
+
+/* Tables */
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.5em 0;
+    font-size: 0.9em;
+}
+
+th, td {
+    border: 1px solid #ddd;
+    padding: 0.3em 0.5em;
+    text-align: left;
+}
+
+th {
+    background-color: #f0f0f0;
+    font-weight: bold;
+}
+
+/* Images */
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+/* Links */
+a {
+    color: #2563eb;
+    text-decoration: none;
+}
+
+/* Horizontal rule */
+hr {
+    border: none;
+    border-top: 1px solid #ddd;
+    margin: 0.8em 0;
+}

--- a/backend/assets/default-pdf.css
+++ b/backend/assets/default-pdf.css
@@ -2,9 +2,8 @@
  *
  * This addresses the common complaint that the default pandoc/weasyprint
  * output has overly large fonts and margins, producing unnecessarily
- * multi-page PDFs.  Administrators can override this file entirely by
- * setting the PDF_CUSTOM_CSS_PATH environment variable to point at a
- * custom .css file on the server.
+ * multi-page PDFs.  Administrators can override this by placing (or
+ * bind-mounting) a file at data/pdf/custom.css.
  */
 
 @page {

--- a/backend/converters/pypandoc_convert.py
+++ b/backend/converters/pypandoc_convert.py
@@ -178,15 +178,16 @@ class PyPandocConverter(ConverterInterface):
     def _get_pdf_css_path(self) -> str | None:
         """Resolve the CSS stylesheet path to use for PDF output.
 
-        Returns the custom path from settings if set and valid,
-        otherwise falls back to the built-in default compact CSS.
+        Prefers a user-provided file at ``data/pdf/custom.css`` (easy to
+        bind-mount in Docker).  Falls back to the built-in compact default
+        when that file is absent.
         """
         settings = get_settings()
-        custom_path = settings.pdf_custom_css_path
-        if custom_path:
-            custom_path = os.path.abspath(custom_path)
-            if os.path.isfile(custom_path):
-                return custom_path
+        custom_path = getattr(settings, 'pdf_custom_css_path', None)
+        if custom_path is not None:
+            custom_file = Path(custom_path)
+            if custom_file.is_file():
+                return str(custom_file.resolve())
 
         # Fall back to the built-in default compact stylesheet
         default_css = Path(__file__).resolve().parent.parent / 'assets' / 'default-pdf.css'

--- a/backend/converters/pypandoc_convert.py
+++ b/backend/converters/pypandoc_convert.py
@@ -175,6 +175,25 @@ class PyPandocConverter(ConverterInterface):
         """
         return self._pandoc_output_format_map.get(fmt.lower(), fmt.lower())
 
+    def _get_pdf_css_path(self) -> str | None:
+        """Resolve the CSS stylesheet path to use for PDF output.
+
+        Returns the custom path from settings if set and valid,
+        otherwise falls back to the built-in default compact CSS.
+        """
+        settings = get_settings()
+        custom_path = settings.pdf_custom_css_path
+        if custom_path:
+            custom_path = os.path.abspath(custom_path)
+            if os.path.isfile(custom_path):
+                return custom_path
+
+        # Fall back to the built-in default compact stylesheet
+        default_css = Path(__file__).resolve().parent.parent / 'assets' / 'default-pdf.css'
+        if default_css.is_file():
+            return str(default_css)
+        return None
+
     def _build_extra_args(self, conversion_input_file: str) -> list[str]:
         extra_args: list[str] = []
         input_dir = str(Path(conversion_input_file).resolve().parent)
@@ -191,6 +210,11 @@ class PyPandocConverter(ConverterInterface):
             extra_args.append(f'--pdf-engine={self._pdf_engine}')
             if self._pdf_engine == 'weasyprint':
                 extra_args.append('--pdf-engine-opt=--quiet')
+
+            # Apply custom or default CSS for compact PDF styling
+            css_path = self._get_pdf_css_path()
+            if css_path:
+                extra_args.append(f'--css={css_path}')
 
         if self.output_type.lower() in ('html', 'revealjs', 'slidy', 's5', 'dzslides'):
             extra_args.append('--standalone')

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -68,11 +68,11 @@ class Settings(BaseSettings):
     # (invalidate) digital signatures so the conversion can proceed.
     invalidate_pdf_digital_signatures: bool = False
 
-    # Path to a custom CSS file applied when converting documents to PDF
-    # via pypandoc (e.g. Markdown -> PDF).  When empty, a built-in default
-    # compact stylesheet is used.  Set to an absolute path on the server
-    # to override with your own styling.
-    pdf_custom_css_path: str = ""
+    # Derived path for optional custom PDF CSS (data_dir/pdf/custom.css).
+    # Docker users can mount a stylesheet there; when absent, a built-in
+    # compact default is used instead.
+    pdf_css_dir: Path | None = None
+    pdf_custom_css_path: Path | None = None
 
     # ===== Authentication =====
     auth_secret_key: str = ""
@@ -183,6 +183,8 @@ class Settings(BaseSettings):
         self.upload_dir = self.data_dir / "uploads"
         self.output_dir = self.data_dir / "outputs"
         self.tmp_dir = self.data_dir / "tmp"
+        self.pdf_css_dir = self.data_dir / "pdf"
+        self.pdf_custom_css_path = self.pdf_css_dir / "custom.css"
 
         self.api_server_url = self.app_url if self.app_url else f"http://{self.host}:{self.port}"
 
@@ -196,6 +198,7 @@ class Settings(BaseSettings):
             self.upload_dir,
             self.output_dir,
             self.tmp_dir,
+            self.pdf_css_dir,
         ]:
             path.mkdir(parents=True, exist_ok=True)
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -68,6 +68,12 @@ class Settings(BaseSettings):
     # (invalidate) digital signatures so the conversion can proceed.
     invalidate_pdf_digital_signatures: bool = False
 
+    # Path to a custom CSS file applied when converting documents to PDF
+    # via pypandoc (e.g. Markdown -> PDF).  When empty, a built-in default
+    # compact stylesheet is used.  Set to an absolute path on the server
+    # to override with your own styling.
+    pdf_custom_css_path: str = ""
+
     # ===== Authentication =====
     auth_secret_key: str = ""
     auth_algorithm: str = "HS256"

--- a/backend/tests/converters/test_pypandoc_css.py
+++ b/backend/tests/converters/test_pypandoc_css.py
@@ -1,0 +1,105 @@
+"""Tests for custom CSS support in the pypandoc converter (Issue #212)."""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# WeasyPrint requires native libraries not available on all platforms.
+# Mock it so the converters package can be imported without issues.
+sys.modules.setdefault('weasyprint', MagicMock())
+
+import pytest
+
+from converters.pypandoc_convert import PyPandocConverter
+
+
+class _FakeSettings:
+    """Minimal settings stub for testing."""
+
+    def __init__(self, pdf_custom_css_path: str = "", tmp_dir: Path | None = None):
+        self.pdf_custom_css_path = pdf_custom_css_path
+        self.tmp_dir = tmp_dir or Path(tempfile.mkdtemp())
+
+
+def _make_converter(output_type: str = "pdf") -> PyPandocConverter:
+    """Create a PyPandocConverter without requiring a real input file."""
+    return PyPandocConverter(
+        input_file="/tmp/fake-input.md",
+        output_dir="/tmp",
+        input_type="md",
+        output_type=output_type,
+    )
+
+
+def test_pdf_css_defaults_to_builtin(tmp_path):
+    """When no custom CSS path is set, the built-in default should be used."""
+    converter = _make_converter()
+    fake = _FakeSettings(pdf_custom_css_path="", tmp_dir=tmp_path / "tmp")
+    with patch("converters.pypandoc_convert.get_settings", return_value=fake):
+        css_path = converter._get_pdf_css_path()
+
+    assert css_path is not None
+    assert css_path.endswith("default-pdf.css")
+    assert os.path.isfile(css_path)
+
+
+def test_pdf_css_uses_custom_path(tmp_path):
+    """When a valid custom CSS path is set, it should be used."""
+    custom_css = tmp_path / "custom.css"
+    custom_css.write_text("body { font-size: 10pt; }")
+
+    converter = _make_converter()
+    fake = _FakeSettings(pdf_custom_css_path=str(custom_css), tmp_dir=tmp_path / "tmp")
+    with patch("converters.pypandoc_convert.get_settings", return_value=fake):
+        css_path = converter._get_pdf_css_path()
+
+    assert css_path is not None
+    assert os.path.abspath(str(custom_css)) == css_path
+
+
+def test_pdf_css_falls_back_when_custom_missing(tmp_path):
+    """When the custom CSS path doesn't exist, fall back to the default."""
+    converter = _make_converter()
+    fake = _FakeSettings(
+        pdf_custom_css_path=str(tmp_path / "nonexistent.css"),
+        tmp_dir=tmp_path / "tmp",
+    )
+    with patch("converters.pypandoc_convert.get_settings", return_value=fake):
+        css_path = converter._get_pdf_css_path()
+
+    assert css_path is not None
+    assert css_path.endswith("default-pdf.css")
+
+
+def test_build_extra_args_includes_css_for_pdf(tmp_path):
+    """The --css flag should be present in extra_args for PDF output."""
+    converter = _make_converter(output_type="pdf")
+    fake = _FakeSettings(pdf_custom_css_path="", tmp_dir=tmp_path / "tmp")
+
+    # Create a minimal fake input file so resource-path resolution works
+    fake_input = tmp_path / "input.md"
+    fake_input.write_text("# Test")
+
+    with patch("converters.pypandoc_convert.get_settings", return_value=fake):
+        extra_args = converter._build_extra_args(str(fake_input))
+
+    css_args = [a for a in extra_args if a.startswith("--css=")]
+    assert len(css_args) == 1
+    assert css_args[0].endswith("default-pdf.css") or "--css=" in css_args[0]
+
+
+def test_build_extra_args_no_css_for_non_pdf(tmp_path):
+    """The --css flag should NOT be present for non-PDF output (e.g. HTML)."""
+    converter = _make_converter(output_type="html")
+    fake = _FakeSettings(pdf_custom_css_path="", tmp_dir=tmp_path / "tmp")
+
+    fake_input = tmp_path / "input.md"
+    fake_input.write_text("# Test")
+
+    with patch("converters.pypandoc_convert.get_settings", return_value=fake):
+        extra_args = converter._build_extra_args(str(fake_input))
+
+    css_args = [a for a in extra_args if a.startswith("--css=")]
+    assert len(css_args) == 0

--- a/backend/tests/converters/test_pypandoc_css.py
+++ b/backend/tests/converters/test_pypandoc_css.py
@@ -18,7 +18,11 @@ from converters.pypandoc_convert import PyPandocConverter
 class _FakeSettings:
     """Minimal settings stub for testing."""
 
-    def __init__(self, pdf_custom_css_path: str = "", tmp_dir: Path | None = None):
+    def __init__(
+        self,
+        pdf_custom_css_path: Path | None = None,
+        tmp_dir: Path | None = None,
+    ):
         self.pdf_custom_css_path = pdf_custom_css_path
         self.tmp_dir = tmp_dir or Path(tempfile.mkdtemp())
 
@@ -34,9 +38,10 @@ def _make_converter(output_type: str = "pdf") -> PyPandocConverter:
 
 
 def test_pdf_css_defaults_to_builtin(tmp_path):
-    """When no custom CSS path is set, the built-in default should be used."""
+    """When no custom CSS file is present, the built-in default should be used."""
     converter = _make_converter()
-    fake = _FakeSettings(pdf_custom_css_path="", tmp_dir=tmp_path / "tmp")
+    missing = tmp_path / "pdf" / "custom.css"
+    fake = _FakeSettings(pdf_custom_css_path=missing, tmp_dir=tmp_path / "tmp")
     with patch("converters.pypandoc_convert.get_settings", return_value=fake):
         css_path = converter._get_pdf_css_path()
 
@@ -45,25 +50,26 @@ def test_pdf_css_defaults_to_builtin(tmp_path):
     assert os.path.isfile(css_path)
 
 
-def test_pdf_css_uses_custom_path(tmp_path):
-    """When a valid custom CSS path is set, it should be used."""
-    custom_css = tmp_path / "custom.css"
+def test_pdf_css_uses_data_dir_custom_file(tmp_path):
+    """When data/pdf/custom.css exists, it should be used."""
+    custom_css = tmp_path / "pdf" / "custom.css"
+    custom_css.parent.mkdir(parents=True)
     custom_css.write_text("body { font-size: 10pt; }")
 
     converter = _make_converter()
-    fake = _FakeSettings(pdf_custom_css_path=str(custom_css), tmp_dir=tmp_path / "tmp")
+    fake = _FakeSettings(pdf_custom_css_path=custom_css, tmp_dir=tmp_path / "tmp")
     with patch("converters.pypandoc_convert.get_settings", return_value=fake):
         css_path = converter._get_pdf_css_path()
 
     assert css_path is not None
-    assert os.path.abspath(str(custom_css)) == css_path
+    assert Path(css_path).resolve() == custom_css.resolve()
 
 
 def test_pdf_css_falls_back_when_custom_missing(tmp_path):
-    """When the custom CSS path doesn't exist, fall back to the default."""
+    """When the data-dir custom CSS file is absent, fall back to the default."""
     converter = _make_converter()
     fake = _FakeSettings(
-        pdf_custom_css_path=str(tmp_path / "nonexistent.css"),
+        pdf_custom_css_path=tmp_path / "pdf" / "custom.css",
         tmp_dir=tmp_path / "tmp",
     )
     with patch("converters.pypandoc_convert.get_settings", return_value=fake):
@@ -76,7 +82,10 @@ def test_pdf_css_falls_back_when_custom_missing(tmp_path):
 def test_build_extra_args_includes_css_for_pdf(tmp_path):
     """The --css flag should be present in extra_args for PDF output."""
     converter = _make_converter(output_type="pdf")
-    fake = _FakeSettings(pdf_custom_css_path="", tmp_dir=tmp_path / "tmp")
+    fake = _FakeSettings(
+        pdf_custom_css_path=tmp_path / "pdf" / "custom.css",
+        tmp_dir=tmp_path / "tmp",
+    )
 
     # Create a minimal fake input file so resource-path resolution works
     fake_input = tmp_path / "input.md"
@@ -93,7 +102,10 @@ def test_build_extra_args_includes_css_for_pdf(tmp_path):
 def test_build_extra_args_no_css_for_non_pdf(tmp_path):
     """The --css flag should NOT be present for non-PDF output (e.g. HTML)."""
     converter = _make_converter(output_type="html")
-    fake = _FakeSettings(pdf_custom_css_path="", tmp_dir=tmp_path / "tmp")
+    fake = _FakeSettings(
+        pdf_custom_css_path=tmp_path / "pdf" / "custom.css",
+        tmp_dir=tmp_path / "tmp",
+    )
 
     fake_input = tmp_path / "input.md"
     fake_input.write_text("# Test")

--- a/backend/tests/core/test_settings.py
+++ b/backend/tests/core/test_settings.py
@@ -22,6 +22,8 @@ def test_derived_paths_created(tmp_path):
     assert s.upload_dir == tmp_path / "data" / "uploads"
     assert s.output_dir == tmp_path / "data" / "outputs"
     assert s.tmp_dir == tmp_path / "data" / "tmp"
+    assert s.pdf_css_dir == tmp_path / "data" / "pdf"
+    assert s.pdf_custom_css_path == tmp_path / "data" / "pdf" / "custom.css"
 
 
 def test_directories_are_created(tmp_path):
@@ -30,6 +32,7 @@ def test_directories_are_created(tmp_path):
     assert s.output_dir.exists()
     assert s.tmp_dir.exists()
     assert s.db_path.parent.exists()
+    assert s.pdf_css_dir.exists()
 
 
 def test_secret_key_auto_generated(tmp_path):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
         - 3313:3313
     volumes:
       - transmute_data:/app/data
+      # Optional: mount a custom stylesheet for Markdown/document -> PDF output.
+      # - ./pdf-custom.css:/app/data/pdf/custom.css:ro
     healthcheck:
       test:
         - "CMD"


### PR DESCRIPTION
## Summary

This PR adds the ability to customize PDF output styling when converting from Markdown and other document formats. It addresses the common complaint that default PDF output has overly large fonts and margins, producing unnecessarily multi-page documents.

## Changes

- **`backend/core/settings.py`**: Add `pdf_custom_css_path` setting (env: `PDF_CUSTOM_CSS_PATH`) for server-level custom CSS configuration
- **`backend/assets/default-pdf.css`** (new): Built-in compact stylesheet that reduces margins (1.5cm), font size (11pt), and spacing — used by default when no custom CSS is configured
- **`backend/converters/pypandoc_convert.py`**: 
  - Add `_get_pdf_css_path()` method that resolves the CSS file to use (custom path from settings, or built-in default)
  - Modify `_build_extra_args()` to pass `--css=<path>` to pandoc when converting to PDF
- **`backend/tests/converters/test_pypandoc_css.py`** (new): 5 tests covering default fallback, custom path, missing file fallback, PDF arg inclusion, and non-PDF exclusion

## How It Works

1. **Default behavior**: When `PDF_CUSTOM_CSS_PATH` is not set, a built-in compact CSS (`backend/assets/default-pdf.css`) is automatically applied to all PDF conversions. This immediately fixes the "big fonts, big margins" issue out of the box.
2. **Custom CSS**: Server admins can set `PDF_CUSTOM_CSS_PATH=/path/to/custom.css` to use their own stylesheet with custom fonts, margins, page size, etc.
3. **Fallback**: If the custom path is set but the file doesn't exist, the system falls back to the built-in default.

## Testing

- All 5 new tests pass
- All 20 existing settings tests still pass
```
```

Closes #212