### PR TITLE
fix: restore animation in animated-to-animated format conversions

### DIFF
--- a/backend/converters/ffmpeg_convert.py
+++ b/backend/converters/ffmpeg_convert.py
@@ -29,6 +29,7 @@ class FFmpegConverter(ConverterInterface):
         'f4v',
         'fli',
         'flc',
+        'webp'
     }
     # Formats FFmpeg can decode but not encode
     _decode_only_formats: set = {
@@ -136,7 +137,7 @@ class FFmpegConverter(ConverterInterface):
         
         # Animated image formats contain no audio stream.
         # Extracting audio from them is not possible.
-        _animated_image_only_formats = {'apng', 'gif', 'fli', 'flc'}
+        _animated_image_only_formats = {'apng', 'gif', 'fli', 'flc', 'webp'}
         if self.input_type in _animated_image_only_formats and self.output_type in self.audio_formats:
             return False
         
@@ -280,7 +281,7 @@ class FFmpegConverter(ConverterInterface):
         if fmt in cls.audio_formats:
             # For audio formats, compatible formats are other audio formats
             return (cls.audio_formats - cls._decode_only_formats) - {fmt}
-        _animated_image_only_formats = {'apng', 'gif', 'fli', 'flc'}
+        _animated_image_only_formats = {'apng', 'gif', 'fli', 'flc', 'webp'}
         if fmt in _animated_image_only_formats:
             # Animated images have no audio stream — only video targets
             return (cls.video_formats - cls._decode_only_formats - {fmt})
@@ -376,10 +377,12 @@ class FFmpegConverter(ConverterInterface):
         # constraints a long or high-resolution video produces enormous output
         # and takes extremely long.  Cap the frame rate and resolution so the
         # conversion stays practical.
-        _animated_image_formats = {'apng', 'gif', 'fli', 'flc'}
-        if self.output_type in _animated_image_formats and self.input_type not in _animated_image_formats:
-            video_filters.append('fps=10,scale=320:-1:flags=lanczos')
-            cmd.extend(['-plays', '0'])
+        _animated_image_formats = {'apng', 'gif', 'fli', 'flc', 'webp'}
+        if self.output_type in _animated_image_formats:
+            if self.input_type not in _animated_image_formats:
+                #only cap fps/scale when converting from a real video source
+                video_filters.append('fps=10,scale=320:-1:flags=lanczos')
+            cmd.extend(['-plays', '0'])  # loop infinitely for GIF/APNG
 
         # FLI/FLC files can have non-standard framerates (e.g. 14 fps) that
         # strict codecs like mpeg1video reject.  Force 25 fps output which is
@@ -391,7 +394,7 @@ class FFmpegConverter(ConverterInterface):
         # Most video codecs/containers cannot handle RGBA input (e.g. from
         # APNG).  Force yuv420p so the alpha channel is stripped before encoding.
         # Animated image outputs that natively support transparency are excluded.
-        _alpha_safe_formats = {'apng', 'gif'}
+        _alpha_safe_formats = {'apng', 'gif', 'webp'}
         if self.output_type in (self.video_formats - _alpha_safe_formats):
             cmd.extend(['-pix_fmt', 'yuv420p'])
             # yuv420p uses 4:2:0 chroma subsampling, which requires both

--- a/backend/tests/converters/test_ffmpeg_convert.py
+++ b/backend/tests/converters/test_ffmpeg_convert.py
@@ -112,3 +112,194 @@ def test_video_to_audio_has_no_padding_filter(monkeypatch, safe_path_test_settin
     ffmpeg_cmd = calls[-1]
     assert '-vn' in ffmpeg_cmd
     assert _vf_value(ffmpeg_cmd) is None
+
+def assert_infinite_loop(cmd):
+    """Assert that the command loops infinitely via -plays 0."""
+    assert '-plays' in cmd
+    assert cmd[cmd.index('-plays') + 1] == '0'
+
+
+def test_gif_to_apng_loops_without_scale_filter(monkeypatch, safe_path_test_settings):
+    """GIF -> APNG must loop infinitely and must NOT apply the fps/scale cap.
+
+    The fps/scale cap is only for real video sources (e.g. mp4 -> apng).
+    Animated-to-animated conversions should preserve the original dimensions.
+    """
+    input_file = safe_path_test_settings.upload_dir / f"{'a' * 31}1.gif"
+    input_file.write_bytes(b"GIF89a fixture")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "converters.ffmpeg_convert.subprocess.run", _fake_run_capturing(calls)
+    )
+
+    converter = FFmpegConverter(
+        input_file=str(input_file),
+        output_dir=str(safe_path_test_settings.output_dir),
+        input_type="gif",
+        output_type="apng",
+    )
+    converter.convert()
+
+    ffmpeg_cmd = calls[-1]
+    assert_infinite_loop(ffmpeg_cmd)
+    assert _vf_value(ffmpeg_cmd) is None
+    assert '-pix_fmt' not in ffmpeg_cmd
+
+
+def test_apng_to_gif_loops_without_scale_filter(monkeypatch, safe_path_test_settings):
+    """APNG -> GIF must loop infinitely without the fps/scale cap."""
+    input_file = safe_path_test_settings.upload_dir / f"{'b' * 31}1.apng"
+    input_file.write_bytes(b"\x89PNG\r\n\x1a\n fixture")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "converters.ffmpeg_convert.subprocess.run", _fake_run_capturing(calls)
+    )
+
+    converter = FFmpegConverter(
+        input_file=str(input_file),
+        output_dir=str(safe_path_test_settings.output_dir),
+        input_type="apng",
+        output_type="gif",
+    )
+    converter.convert()
+
+    ffmpeg_cmd = calls[-1]
+    assert_infinite_loop(ffmpeg_cmd)
+    assert _vf_value(ffmpeg_cmd) is None
+    assert '-pix_fmt' not in ffmpeg_cmd
+
+
+def test_gif_to_webp_loops_without_scale_filter(monkeypatch, safe_path_test_settings):
+    """GIF -> WebP must loop and not apply the fps/scale cap."""
+    input_file = safe_path_test_settings.upload_dir / f"{'c' * 31}1.gif"
+    input_file.write_bytes(b"GIF89a fixture")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "converters.ffmpeg_convert.subprocess.run", _fake_run_capturing(calls)
+    )
+
+    converter = FFmpegConverter(
+        input_file=str(input_file),
+        output_dir=str(safe_path_test_settings.output_dir),
+        input_type="gif",
+        output_type="webp",
+    )
+    converter.convert()
+
+    ffmpeg_cmd = calls[-1]
+    assert_infinite_loop(ffmpeg_cmd)
+    assert _vf_value(ffmpeg_cmd) is None
+    assert '-pix_fmt' not in ffmpeg_cmd
+
+
+def test_webp_to_gif_loops_without_scale_filter(monkeypatch, safe_path_test_settings):
+    """WebP -> GIF must loop and not apply the fps/scale cap."""
+    input_file = safe_path_test_settings.upload_dir / f"{'a' * 31}2.webp"
+    input_file.write_bytes(b"RIFF fixture")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "converters.ffmpeg_convert.subprocess.run", _fake_run_capturing(calls)
+    )
+
+    converter = FFmpegConverter(
+        input_file=str(input_file),
+        output_dir=str(safe_path_test_settings.output_dir),
+        input_type="webp",
+        output_type="gif",
+    )
+    converter.convert()
+
+    ffmpeg_cmd = calls[-1]
+    assert_infinite_loop(ffmpeg_cmd)
+    assert _vf_value(ffmpeg_cmd) is None
+    assert '-pix_fmt' not in ffmpeg_cmd
+
+
+def test_webp_to_apng_loops_without_scale_filter(monkeypatch, safe_path_test_settings):
+    """WebP -> APNG must loop and not apply the fps/scale cap."""
+    input_file = safe_path_test_settings.upload_dir / f"{'b' * 31}2.webp"
+    input_file.write_bytes(b"RIFF fixture")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "converters.ffmpeg_convert.subprocess.run", _fake_run_capturing(calls)
+    )
+
+    converter = FFmpegConverter(
+        input_file=str(input_file),
+        output_dir=str(safe_path_test_settings.output_dir),
+        input_type="webp",
+        output_type="apng",
+    )
+    converter.convert()
+
+    ffmpeg_cmd = calls[-1]
+    assert_infinite_loop(ffmpeg_cmd)
+    assert _vf_value(ffmpeg_cmd) is None
+    assert '-pix_fmt' not in ffmpeg_cmd
+
+
+def test_apng_to_webp_loops_without_scale_filter(monkeypatch, safe_path_test_settings):
+    """APNG -> WebP must loop and not apply the fps/scale cap."""
+    input_file = safe_path_test_settings.upload_dir / f"{'c' * 31}2.apng"
+    input_file.write_bytes(b"\x89PNG\r\n\x1a\n fixture")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "converters.ffmpeg_convert.subprocess.run", _fake_run_capturing(calls)
+    )
+
+    converter = FFmpegConverter(
+        input_file=str(input_file),
+        output_dir=str(safe_path_test_settings.output_dir),
+        input_type="apng",
+        output_type="webp",
+    )
+    converter.convert()
+
+    ffmpeg_cmd = calls[-1]
+    assert_infinite_loop(ffmpeg_cmd)
+    assert _vf_value(ffmpeg_cmd) is None
+    assert '-pix_fmt' not in ffmpeg_cmd
+
+
+def test_mp4_to_webp_applies_scale_filter(monkeypatch, safe_path_test_settings):
+    """MP4 -> WebP (video to animated image) must apply the fps/scale cap."""
+    input_file = safe_path_test_settings.upload_dir / f"{'1' * 31}3.mp4"
+    input_file.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "converters.ffmpeg_convert.subprocess.run", _fake_run_capturing(calls)
+    )
+
+    converter = FFmpegConverter(
+        input_file=str(input_file),
+        output_dir=str(safe_path_test_settings.output_dir),
+        input_type="mp4",
+        output_type="webp",
+    )
+    converter.convert()
+
+    ffmpeg_cmd = calls[-1]
+    assert_infinite_loop(ffmpeg_cmd)
+    assert _vf_value(ffmpeg_cmd) == 'fps=10,scale=320:-1:flags=lanczos'
+    assert '-pix_fmt' not in ffmpeg_cmd
+
+
+def test_webp_cannot_convert_to_audio(safe_path_test_settings):
+    """WebP is an animated image format — converting to audio must be rejected."""
+    input_file = safe_path_test_settings.upload_dir / f"{'b' * 31}3.webp"
+    input_file.write_bytes(b"RIFF fixture")
+
+    converter = FFmpegConverter(
+        input_file=str(input_file),
+        output_dir=str(safe_path_test_settings.output_dir),
+        input_type="webp",
+        output_type="mp3",
+    )
+    assert converter.can_convert() is False


### PR DESCRIPTION
## What
- Added `webp` to `video_formats`, `_animated_image_formats`, and `_alpha_safe_formats` in `ffmpeg_convert.py`
- Fixed the loop flag block so animated-to-animated conversions (GIF→WebP, WebP→GIF, GIF→APNG, APNG→WebP, etc.) correctly receive `-plays 0` and loop infinitely
- The fps/scale cap (`fps=10,scale=320:-1:flags=lanczos`) is now only applied when converting from a real video source, not between animated image formats
- Blocked WebP→audio conversions in `can_convert()` and `get_formats_compatible_with()` since animated images have no audio stream

## Why
Fixes #213  — animated-to-animated format conversions were producing static single-frame output instead of animating. The root cause was two bugs:
1. `webp` was missing from `_animated_image_formats`, so it never received the loop flag or transparency treatment
2. The loop flag block had a condition (`input_type not in _animated_image_formats`) that skipped it entirely for animated-to-animated conversions, so GIF→APNG, WebP→GIF etc. never got `-plays 0`

## Testing
- Added 8 new unit tests covering all animated format conversion pairs (GIF↔APNG, GIF↔WebP, APNG↔WebP, MP4→WebP, WebP→audio rejection) — all pass
- Full test suite passes: 353 passed, 3 skipped, 0 failures (`python -m pytest --ignore=tests/converters/test_all_conversions.py`)


---

- [x] Tested locally
- [ ] Docs updated if needed (bug fix — no docs change needed)