### PR TITLE
feat: add API-backed pagination for files and jobs

### DIFF
--- a/backend/api/routes/compression_jobs.py
+++ b/backend/api/routes/compression_jobs.py
@@ -4,7 +4,7 @@ These endpoints persist compression requests as durable jobs that a background
 worker processes asynchronously, in contrast with the synchronous
 ``POST /api/compressions`` endpoint which runs the compression inline.
 """
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from api.deps import (
     get_compression_job_db,
@@ -20,6 +20,7 @@ from api.schemas import (
 from core import validate_safe_path
 from db import CompressionJobDB, FileDB
 from registry import compressor_registry
+from core.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, build_pagination
 
 
 router = APIRouter(prefix="/compression-jobs", tags=["compression-jobs"])
@@ -60,6 +61,9 @@ def _serialize_job(job: dict) -> dict:
 )
 def list_jobs(
     status_filter: str | None = None,
+    include_completed: bool = True,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     job_db: CompressionJobDB = Depends(get_compression_job_db),
     current_user: dict = Depends(get_current_active_user),
 ):
@@ -67,9 +71,27 @@ def list_jobs(
 
     Optional ``status_filter`` query parameter narrows the result to one of:
     ``queued``, ``running``, ``completed``, ``failed``, ``cancelled``.
+    Set ``include_completed=false`` when completed records are loaded from the
+    compressions endpoint instead.
     """
-    rows = job_db.list_jobs(user_id=current_user["uuid"], status=status_filter)
-    return {"jobs": [_serialize_job(row) for row in rows]}
+    user_id = current_user["uuid"]
+    exclude_status = None if include_completed or status_filter is not None else "completed"
+    total_items = job_db.count_jobs(
+        user_id=user_id,
+        status=status_filter,
+        exclude_status=exclude_status,
+    )
+    rows = job_db.list_jobs(
+        user_id=user_id,
+        status=status_filter,
+        exclude_status=exclude_status,
+        limit=page_size,
+        offset=(page - 1) * page_size,
+    )
+    return {
+        "jobs": [_serialize_job(row) for row in rows],
+        "pagination": build_pagination(total_items, page, page_size),
+    }
 
 
 @router.post(

--- a/backend/api/routes/compressions.py
+++ b/backend/api/routes/compressions.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from registry import compressor_registry
 from core import get_settings, delete_file_and_metadata
 from db import CompressionDB, FileDB, CompressionRelationsDB, SettingsDB, DefaultCompressionLevelsDB
@@ -12,6 +12,7 @@ from api.deps import (
     get_default_compression_levels_db,
 )
 from api.schemas import CompressionRequest, CompressionListResponse, FileMetadata, ErrorResponse, FileDeleteResponse
+from core.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, build_pagination
 
 
 router = APIRouter(prefix="/compressions", tags=["compressions"])
@@ -32,22 +33,34 @@ COMPRESSED_DIR = settings.output_dir
         }
 )
 def list_compressions(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     comp_db: CompressionDB = Depends(get_compression_db),
     comp_rel_db: CompressionRelationsDB = Depends(get_compression_relations_db),
     current_user: dict = Depends(get_current_active_user),
 ):
-    """List all completed compressions for the current user."""
-    compressed_files = comp_db.list_files(user_id=current_user["uuid"])
+    """List completed compressions for the current user, newest-first."""
+    user_id = current_user["uuid"]
+    total_items = comp_db.count_files(user_id=user_id)
+    compressed_files = comp_db.list_files(
+        user_id=user_id,
+        limit=page_size,
+        offset=(page - 1) * page_size,
+    )
     compressed_files_dict = {f['id']: f for f in compressed_files}
 
-    relations = comp_rel_db.list_relations(user_id=current_user["uuid"])
+    relations = comp_rel_db.list_relations_for_compressions(
+        list(compressed_files_dict),
+        user_id=user_id,
+    )
+    relations_by_compression = {rel['compressed_file_id']: rel for rel in relations}
     # For each relation, create a compression-centric record with original file metadata from the relation.
     # This uses denormalized data so original files can be deleted without breaking history.
     compression_records = []
-    for rel in relations:
-        comp_id = rel['compressed_file_id']
-        if comp_id in compressed_files_dict:
-            record = dict(compressed_files_dict[comp_id])
+    for comp_id, compressed_file in compressed_files_dict.items():
+        rel = relations_by_compression.get(comp_id)
+        if rel is not None:
+            record = dict(compressed_file)
             # Build original_file metadata from denormalized relation data
             record['original_file'] = {
                 'id': rel['original_file_id'],
@@ -58,7 +71,10 @@ def list_compressions(
             }
             compression_records.append(record)
 
-    return {"compressions": compression_records}
+    return {
+        "compressions": compression_records,
+        "pagination": build_pagination(total_items, page, page_size),
+    }
 
 
 @router.post(

--- a/backend/api/routes/conversions.py
+++ b/backend/api/routes/conversions.py
@@ -1,13 +1,14 @@
 from pathlib import Path
 import shutil
 import uuid
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from registry import registry
 from core import get_settings, sanitize_extension, delete_file_and_metadata
 from db import ConversionDB, FileDB, ConversionRelationsDB, SettingsDB, DefaultQualitiesDB
 from services import ConversionFailedError, run_conversion_job
 from api.deps import get_current_active_user, get_file_db, get_conversion_db, get_conversion_relations_db, get_settings_db, get_default_qualities_db
 from api.schemas import ConversionRequest, ConversionListResponse, FileMetadata, ErrorResponse, FileDeleteResponse
+from core.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, build_pagination
 
 
 router = APIRouter(prefix="/conversions", tags=["conversions"])
@@ -43,22 +44,34 @@ def copy_webvideo_to_mp4(input_path: str, temp_dir: Path, converted_id: str) -> 
         }
 )
 def list_conversions(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     conv_db: ConversionDB = Depends(get_conversion_db),
     conv_rel_db: ConversionRelationsDB = Depends(get_conversion_relations_db),
     current_user: dict = Depends(get_current_active_user),
 ):
-    """List all completed conversions for the current user."""
-    converted_files = conv_db.list_files(user_id=current_user["uuid"])
+    """List completed conversions for the current user, newest-first."""
+    user_id = current_user["uuid"]
+    total_items = conv_db.count_files(user_id=user_id)
+    converted_files = conv_db.list_files(
+        user_id=user_id,
+        limit=page_size,
+        offset=(page - 1) * page_size,
+    )
     converted_files_dict = {f['id']: f for f in converted_files}
 
-    relations = conv_rel_db.list_relations(user_id=current_user["uuid"])
+    relations = conv_rel_db.list_relations_for_conversions(
+        list(converted_files_dict),
+        user_id=user_id,
+    )
+    relations_by_conversion = {rel['converted_file_id']: rel for rel in relations}
     # For each relation, create a conversion-centric record with original file metadata from the relation
     # This uses denormalized data so original files can be deleted without breaking history
     conversion_records = []
-    for rel in relations:
-        conv_id = rel['converted_file_id']
-        if conv_id in converted_files_dict:
-            record = dict(converted_files_dict[conv_id])
+    for conv_id, converted_file in converted_files_dict.items():
+        rel = relations_by_conversion.get(conv_id)
+        if rel is not None:
+            record = dict(converted_file)
             # Build original_file metadata from denormalized relation data
             record['original_file'] = {
                 'id': rel['original_file_id'],
@@ -69,7 +82,10 @@ def list_conversions(
             }
             conversion_records.append(record)
     
-    return {"conversions": conversion_records}
+    return {
+        "conversions": conversion_records,
+        "pagination": build_pagination(total_items, page, page_size),
+    }
 
 
 @router.post(

--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -4,7 +4,7 @@ import hashlib
 import mimetypes
 import logging
 
-from fastapi import APIRouter, File, UploadFile, HTTPException, Depends, BackgroundTasks
+from fastapi import APIRouter, File, UploadFile, HTTPException, Depends, BackgroundTasks, Query
 from fastapi.responses import FileResponse
 from zipfile import ZipFile
 from pathlib import Path
@@ -16,6 +16,7 @@ from api.schemas import FileListResponse, FileUploadResponse, FileUrlUploadRespo
 from registry import downloader_registry
 from downloaders import DownloadError, YtDlpDownloader
 from converters.ffmpeg_convert import FFmpegConverter
+from core.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, build_pagination
 
 logger = logging.getLogger(__name__)
 
@@ -117,14 +118,25 @@ async def save_file(file: UploadFile, db: FileDB, user_id: str) -> dict:
     }
 )
 def list_files(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     file_db: FileDB = Depends(get_file_db),
     current_user: dict = Depends(get_current_active_user),
 ):
-    """List all uploaded files for the current user"""
-    files = file_db.list_files(user_id=current_user["uuid"])
+    """List uploaded files for the current user, newest-first."""
+    user_id = current_user["uuid"]
+    total_items = file_db.count_files(user_id=user_id)
+    files = file_db.list_files(
+        user_id=user_id,
+        limit=page_size,
+        offset=(page - 1) * page_size,
+    )
     for file in files:
         file["compatible_formats"] = converter_registry.get_compatible_formats_and_qualities(file["media_type"])
-    return {"files": files}
+    return {
+        "files": files,
+        "pagination": build_pagination(total_items, page, page_size),
+    }
 
 
 @router.post(

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -4,7 +4,7 @@ These endpoints persist conversion requests as durable jobs that a background
 worker processes asynchronously, in contrast with the legacy synchronous
 ``POST /api/conversions`` endpoint which still runs the conversion inline.
 """
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from api.deps import (
     get_conversion_job_db,
@@ -20,6 +20,7 @@ from api.schemas import (
 from core import sanitize_extension, validate_safe_path
 from db import ConversionJobDB, FileDB
 from registry import registry
+from core.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, build_pagination
 
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
@@ -61,6 +62,9 @@ def _serialize_job(job: dict) -> dict:
 )
 def list_jobs(
     status_filter: str | None = None,
+    include_completed: bool = True,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     job_db: ConversionJobDB = Depends(get_conversion_job_db),
     current_user: dict = Depends(get_current_active_user),
 ):
@@ -68,9 +72,27 @@ def list_jobs(
 
     Optional ``status_filter`` query parameter narrows the result to one of:
     ``queued``, ``running``, ``completed``, ``failed``, ``cancelled``.
+    Set ``include_completed=false`` when completed records are loaded from the
+    conversions endpoint instead.
     """
-    rows = job_db.list_jobs(user_id=current_user["uuid"], status=status_filter)
-    return {"jobs": [_serialize_job(row) for row in rows]}
+    user_id = current_user["uuid"]
+    exclude_status = None if include_completed or status_filter is not None else "completed"
+    total_items = job_db.count_jobs(
+        user_id=user_id,
+        status=status_filter,
+        exclude_status=exclude_status,
+    )
+    rows = job_db.list_jobs(
+        user_id=user_id,
+        status=status_filter,
+        exclude_status=exclude_status,
+        limit=page_size,
+        offset=(page - 1) * page_size,
+    )
+    return {
+        "jobs": [_serialize_job(row) for row in rows],
+        "pagination": build_pagination(total_items, page, page_size),
+    }
 
 
 @router.post(

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -39,8 +39,18 @@ class ConversionJobResponse(BaseModel):
     updated_at: Optional[str] = Field(None, description="Last update timestamp")
 
 
+class PaginationMetadata(BaseModel):
+    total_items: int = Field(..., description="Total number of matching records")
+    total_pages: int = Field(..., description="Total number of available pages")
+    current_page: int = Field(..., description="Current 1-based page number")
+    page_size: int = Field(..., description="Maximum number of records per page")
+    has_next: bool = Field(..., description="Whether another page is available")
+    has_prev: bool = Field(..., description="Whether a previous page is available")
+
+
 class ConversionJobListResponse(BaseModel):
     jobs: list[ConversionJobResponse] = Field(..., description="List of conversion jobs for the current user")
+    pagination: PaginationMetadata = Field(..., description="Pagination metadata")
 
 
 class FileMetadata(BaseModel):
@@ -72,6 +82,7 @@ class ConversionItem(BaseModel):
 
 class ConversionListResponse(BaseModel):
     conversions: list[ConversionItem] = Field(..., description="List of completed conversions")
+    pagination: PaginationMetadata = Field(..., description="Pagination metadata")
 
 class ConverterMetadata(BaseModel):
     name: str = Field(..., json_schema_extra={"example": "drawio_convert"})
@@ -117,6 +128,7 @@ class ReadinessResponse(BaseModel):
 
 class FileListResponse(BaseModel):
     files: list[FileMetadata] = Field(..., description="List of uploaded files")
+    pagination: PaginationMetadata = Field(..., description="Pagination metadata")
 
 
 class UrlUploadRequest(BaseModel):
@@ -259,6 +271,7 @@ class CompressionJobResponse(BaseModel):
 
 class CompressionJobListResponse(BaseModel):
     jobs: list[CompressionJobResponse] = Field(..., description="List of compression jobs for the current user")
+    pagination: PaginationMetadata = Field(..., description="Pagination metadata")
 
 
 class CompressionItem(BaseModel):
@@ -274,6 +287,7 @@ class CompressionItem(BaseModel):
 
 class CompressionListResponse(BaseModel):
     compressions: list[CompressionItem] = Field(..., description="List of completed compressions")
+    pagination: PaginationMetadata = Field(..., description="Pagination metadata")
 
 
 class DefaultCompressionLevelMapping(BaseModel):

--- a/backend/core/pagination.py
+++ b/backend/core/pagination.py
@@ -1,0 +1,18 @@
+from math import ceil
+
+
+DEFAULT_PAGE_SIZE = 20
+MAX_PAGE_SIZE = 100
+
+
+def build_pagination(total_items: int, page: int, page_size: int) -> dict:
+    """Build consistent pagination metadata for list endpoints."""
+    total_pages = ceil(total_items / page_size) if total_items else 0
+    return {
+        "total_items": total_items,
+        "total_pages": total_pages,
+        "current_page": page,
+        "page_size": page_size,
+        "has_next": page < total_pages,
+        "has_prev": page > 1 and total_pages > 0,
+    }

--- a/backend/db/compression_job_db.py
+++ b/backend/db/compression_job_db.py
@@ -188,6 +188,7 @@ class CompressionJobDB:
         self,
         user_id: str | None = None,
         status: str | None = None,
+        exclude_status: str | None = None,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict]:
@@ -200,6 +201,9 @@ class CompressionJobDB:
         if status is not None:
             clauses.append("status = ?")
             params.append(status)
+        if exclude_status is not None:
+            clauses.append("status != ?")
+            params.append(exclude_status)
         where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         limit_sql = ""
         if limit is not None:
@@ -214,7 +218,12 @@ class CompressionJobDB:
         )
         return [dict(row) for row in cursor.fetchall()]
 
-    def count_jobs(self, user_id: str | None = None, status: str | None = None) -> int:
+    def count_jobs(
+        self,
+        user_id: str | None = None,
+        status: str | None = None,
+        exclude_status: str | None = None,
+    ) -> int:
         """Count jobs, optionally filtered by owner and/or status."""
         clauses: list[str] = []
         params: list = []
@@ -224,6 +233,9 @@ class CompressionJobDB:
         if status is not None:
             clauses.append("status = ?")
             params.append(status)
+        if exclude_status is not None:
+            clauses.append("status != ?")
+            params.append(exclude_status)
         where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
 
         cursor = self.conn.cursor()

--- a/backend/db/compression_relations_db.py
+++ b/backend/db/compression_relations_db.py
@@ -183,6 +183,24 @@ class CompressionRelationsDB:
         rows = cursor.fetchall()
         return [dict(row) for row in rows]
 
+    def list_relations_for_compressions(
+        self,
+        compressed_file_ids: list[str],
+        user_id: str,
+    ) -> list[dict]:
+        """Retrieve relations for a page of compressed files in one query."""
+        if not compressed_file_ids:
+            return []
+        placeholders = ", ".join("?" for _ in compressed_file_ids)
+        cursor = self.conn.cursor()
+        cursor.row_factory = sqlite3.Row
+        cursor.execute(
+            f"SELECT * FROM {self.TABLE_NAME} "  # nosec B608
+            f"WHERE user_id = ? AND compressed_file_id IN ({placeholders})",
+            (user_id, *compressed_file_ids),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
     def close(self) -> None:
         """Close the current thread's database connection."""
         if hasattr(self._local, 'conn') and self._local.conn:

--- a/backend/db/conversion_job_db.py
+++ b/backend/db/conversion_job_db.py
@@ -189,6 +189,7 @@ class ConversionJobDB:
         self,
         user_id: str | None = None,
         status: str | None = None,
+        exclude_status: str | None = None,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict]:
@@ -201,6 +202,9 @@ class ConversionJobDB:
         if status is not None:
             clauses.append("status = ?")
             params.append(status)
+        if exclude_status is not None:
+            clauses.append("status != ?")
+            params.append(exclude_status)
         where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         limit_sql = ""
         if limit is not None:
@@ -215,7 +219,12 @@ class ConversionJobDB:
         )
         return [dict(row) for row in cursor.fetchall()]
 
-    def count_jobs(self, user_id: str | None = None, status: str | None = None) -> int:
+    def count_jobs(
+        self,
+        user_id: str | None = None,
+        status: str | None = None,
+        exclude_status: str | None = None,
+    ) -> int:
         """Count jobs, optionally filtered by owner and/or status."""
         clauses: list[str] = []
         params: list = []
@@ -225,6 +234,9 @@ class ConversionJobDB:
         if status is not None:
             clauses.append("status = ?")
             params.append(status)
+        if exclude_status is not None:
+            clauses.append("status != ?")
+            params.append(exclude_status)
         where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
 
         cursor = self.conn.cursor()

--- a/backend/db/conversion_relations_db.py
+++ b/backend/db/conversion_relations_db.py
@@ -180,6 +180,24 @@ class ConversionRelationsDB:
         rows = cursor.fetchall()
         return [dict(row) for row in rows]
 
+    def list_relations_for_conversions(
+        self,
+        converted_file_ids: list[str],
+        user_id: str,
+    ) -> list[dict]:
+        """Retrieve relations for a page of converted files in one query."""
+        if not converted_file_ids:
+            return []
+        placeholders = ", ".join("?" for _ in converted_file_ids)
+        cursor = self.conn.cursor()
+        cursor.row_factory = sqlite3.Row
+        cursor.execute(
+            f"SELECT * FROM {self.TABLE_NAME} "  # nosec B608
+            f"WHERE user_id = ? AND converted_file_id IN ({placeholders})",
+            (user_id, *converted_file_ids),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
     def close(self) -> None:
         """Close the current thread's database connection."""
         if hasattr(self._local, 'conn') and self._local.conn:

--- a/backend/db/file_db.py
+++ b/backend/db/file_db.py
@@ -78,6 +78,12 @@ class FileDB:
         # Assign pre-auth orphaned rows to the first admin
         assign_orphaned_rows_to_admin(self.conn, self.TABLE_NAME)
 
+        with self.conn:
+            self.conn.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_{self.TABLE_NAME}_user_created "  # nosec B608
+                f"ON {self.TABLE_NAME} (user_id, created_at DESC)"
+            )
+
     def create_tables(self) -> None:
         """Create the file metadata table if it does not already exist."""
         self._create_base_tables()
@@ -173,16 +179,44 @@ class FileDB:
             return None
         return self._refresh_pdf_media_type(dict(row))
 
-    def list_files(self, user_id: str | None = None) -> list[dict]:
-        """Retrieve metadata for files, optionally filtered by user."""
+    def list_files(
+        self,
+        user_id: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict]:
+        """Retrieve file metadata newest-first, optionally filtered and paginated."""
         cursor = self.conn.cursor()
         cursor.row_factory = sqlite3.Row
+        params: list = []
+        where_sql = ""
         if user_id is not None:
-            cursor.execute(f"SELECT * FROM {self.TABLE_NAME} WHERE user_id = ?", (user_id,))  # nosec B608
-        else:
-            cursor.execute(f"SELECT * FROM {self.TABLE_NAME}")  # nosec B608
+            where_sql = "WHERE user_id = ?"
+            params.append(user_id)
+        limit_sql = ""
+        if limit is not None:
+            limit_sql = " LIMIT ? OFFSET ?"
+            params.extend([int(limit), int(offset)])
+        cursor.execute(
+            f"SELECT * FROM {self.TABLE_NAME} {where_sql} "  # nosec B608
+            f"ORDER BY created_at DESC, rowid DESC{limit_sql}",
+            tuple(params),
+        )
         rows = cursor.fetchall()
         return [self._refresh_pdf_media_type(dict(row)) for row in rows]
+
+    def count_files(self, user_id: str | None = None) -> int:
+        """Count files, optionally restricted to a specific owner."""
+        cursor = self.conn.cursor()
+        if user_id is not None:
+            cursor.execute(
+                f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE user_id = ?",  # nosec B608
+                (user_id,),
+            )
+        else:
+            cursor.execute(f"SELECT COUNT(*) FROM {self.TABLE_NAME}")  # nosec B608
+        row = cursor.fetchone()
+        return int(row[0]) if row is not None else 0
 
     def delete_file_metadata(self, file_id: str) -> None:
         """Delete the metadata record for a specific file.

--- a/backend/tests/api/test_pagination.py
+++ b/backend/tests/api/test_pagination.py
@@ -1,0 +1,23 @@
+from core.pagination import build_pagination
+
+
+def test_build_pagination_for_middle_page():
+    assert build_pagination(total_items=45, page=2, page_size=20) == {
+        "total_items": 45,
+        "total_pages": 3,
+        "current_page": 2,
+        "page_size": 20,
+        "has_next": True,
+        "has_prev": True,
+    }
+
+
+def test_build_pagination_for_empty_result():
+    assert build_pagination(total_items=0, page=1, page_size=20) == {
+        "total_items": 0,
+        "total_pages": 0,
+        "current_page": 1,
+        "page_size": 20,
+        "has_next": False,
+        "has_prev": False,
+    }

--- a/backend/tests/core/test_compression_job_db.py
+++ b/backend/tests/core/test_compression_job_db.py
@@ -98,6 +98,18 @@ def test_count_jobs_filters_by_user_and_status(job_db):
     assert job_db.count_jobs(status="queued") == 2
 
 
+def test_list_and_count_jobs_can_exclude_completed(job_db):
+    completed = job_db.insert_job(_make_job(user_id="user-a", source_id="f1"))
+    job_db.insert_job(_make_job(user_id="user-a", source_id="f2"))
+    job_db.claim_next_queued_job()
+    job_db.mark_completed(completed["id"], output_file_id="out-1")
+
+    jobs = job_db.list_jobs(user_id="user-a", exclude_status="completed")
+
+    assert [job["source_file_id"] for job in jobs] == ["f2"]
+    assert job_db.count_jobs(user_id="user-a", exclude_status="completed") == 1
+
+
 def test_claim_next_queued_job_marks_running(job_db):
     job1 = job_db.insert_job(_make_job(source_id="f1"))
     job2 = job_db.insert_job(_make_job(source_id="f2"))

--- a/backend/tests/core/test_conversion_job_db.py
+++ b/backend/tests/core/test_conversion_job_db.py
@@ -100,6 +100,18 @@ def test_count_jobs_filters_by_user_and_status(job_db):
     assert job_db.count_jobs(status="queued") == 2
 
 
+def test_list_and_count_jobs_can_exclude_completed(job_db):
+    completed = job_db.insert_job(_make_job(user_id="user-a", source_id="f1"))
+    job_db.insert_job(_make_job(user_id="user-a", source_id="f2"))
+    job_db.claim_next_queued_job()
+    job_db.mark_completed(completed["id"], output_file_id="out-1")
+
+    jobs = job_db.list_jobs(user_id="user-a", exclude_status="completed")
+
+    assert [job["source_file_id"] for job in jobs] == ["f2"]
+    assert job_db.count_jobs(user_id="user-a", exclude_status="completed") == 1
+
+
 def test_claim_next_queued_job_marks_running(job_db):
     job1 = job_db.insert_job(_make_job(source_id="f1"))
     job2 = job_db.insert_job(_make_job(source_id="f2"))

--- a/backend/tests/core/test_file_db.py
+++ b/backend/tests/core/test_file_db.py
@@ -1,0 +1,42 @@
+import pytest
+
+from db import FileDB
+
+
+@pytest.fixture
+def file_db(monkeypatch):
+    monkeypatch.setattr(FileDB, "DB_PATH", ":memory:")
+    db = FileDB()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _metadata(file_id: str, user_id: str) -> dict:
+    return {
+        "id": file_id,
+        "storage_path": f"/tmp/{file_id}.txt",
+        "original_filename": f"{file_id}.txt",
+        "media_type": "txt",
+        "extension": ".txt",
+        "size_bytes": 10,
+        "sha256_checksum": file_id,
+        "user_id": user_id,
+    }
+
+
+def test_list_files_paginates_newest_first_and_filters_by_user(file_db):
+    file_db.insert_file_metadata(_metadata("first", "user-a"))
+    file_db.insert_file_metadata(_metadata("second", "user-a"))
+    file_db.insert_file_metadata(_metadata("other", "user-b"))
+    file_db.insert_file_metadata(_metadata("third", "user-a"))
+
+    first_page = file_db.list_files(user_id="user-a", limit=2, offset=0)
+    second_page = file_db.list_files(user_id="user-a", limit=2, offset=2)
+
+    assert [item["id"] for item in first_page] == ["third", "second"]
+    assert [item["id"] for item in second_page] == ["first"]
+    assert file_db.count_files(user_id="user-a") == 3
+    assert file_db.count_files(user_id="user-b") == 1
+    assert file_db.count_files() == 4

--- a/frontend/src/components/Pagination.test.tsx
+++ b/frontend/src/components/Pagination.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import Pagination from './Pagination'
+import type { PaginationMetadata } from '../utils/pagination'
+
+
+const pagination: PaginationMetadata = {
+  total_items: 45,
+  total_pages: 3,
+  current_page: 2,
+  page_size: 20,
+  has_next: true,
+  has_prev: true,
+}
+
+
+describe('Pagination', () => {
+  it('navigates to adjacent pages', () => {
+    const onPageChange = vi.fn()
+    render(<Pagination pagination={pagination} onPageChange={onPageChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(onPageChange).toHaveBeenNthCalledWith(1, 1)
+    expect(onPageChange).toHaveBeenNthCalledWith(2, 3)
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument()
+  })
+
+  it('does not render for a single page', () => {
+    const { container } = render(
+      <Pagination
+        pagination={{ ...pagination, total_items: 10, total_pages: 1, current_page: 1 }}
+        onPageChange={() => {}}
+      />,
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next'
+import type { PaginationMetadata } from '../utils/pagination'
+
+interface PaginationProps {
+  pagination: PaginationMetadata
+  onPageChange: (page: number) => void
+  disabled?: boolean
+}
+
+function Pagination({ pagination, onPageChange, disabled = false }: PaginationProps) {
+  const { t } = useTranslation()
+
+  if (pagination.total_pages <= 1) return null
+
+  return (
+    <nav className="mt-6 flex items-center justify-center gap-4" aria-label={t('pagination.label')}>
+      <button
+        type="button"
+        onClick={() => onPageChange(pagination.current_page - 1)}
+        disabled={disabled || !pagination.has_prev}
+        className="rounded-lg border border-primary/40 px-4 py-2 text-sm font-semibold text-primary-light transition hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {t('pagination.previous')}
+      </button>
+      <span className="text-sm text-text-muted">
+        {t('pagination.pageOf', {
+          current: pagination.current_page,
+          total: pagination.total_pages,
+        })}
+      </span>
+      <button
+        type="button"
+        onClick={() => onPageChange(pagination.current_page + 1)}
+        disabled={disabled || !pagination.has_next}
+        className="rounded-lg border border-primary/40 px-4 py-2 text-sm font-semibold text-primary-light transition hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {t('pagination.next')}
+      </button>
+    </nav>
+  )
+}
+
+export default Pagination

--- a/frontend/src/i18n/az.json
+++ b/frontend/src/i18n/az.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Faylı atın, formatı seçin, Transmute."
   },
+  "pagination": {
+    "label": "Səhifələmə",
+    "previous": "Əvvəlki",
+    "next": "Növbəti",
+    "pageOf": "{{total}} səhifədən {{current}}-ci"
+  },
   "titles": {
     "signIn": "Transmute - Daxil Ol",
     "converter": "Transmute - İş sahəsi",

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Přetáhni soubor, vyber formát, konvertuj."
   },
+  "pagination": {
+    "label": "Stránkování",
+    "previous": "Předchozí",
+    "next": "Další",
+    "pageOf": "Strana {{current}} z {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Přihlášení",
     "converter": "Transmute - Pracovní prostor",

--- a/frontend/src/i18n/da.json
+++ b/frontend/src/i18n/da.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Træk en fil ind, vælg et format, Transmute."
   },
+  "pagination": {
+    "label": "Sidenavigation",
+    "previous": "Forrige",
+    "next": "Næste",
+    "pageOf": "Side {{current}} af {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Log ind",
     "converter": "Transmute - Arbejdsområde",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Datei hochladen, Format wählen, konvertieren."
   },
+  "pagination": {
+    "label": "Seitennavigation",
+    "previous": "Zurück",
+    "next": "Weiter",
+    "pageOf": "Seite {{current}} von {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Anmelden",
     "converter": "Transmute - Arbeitsbereich",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Drop a file, pick a format, Transmute."
   },
+  "pagination": {
+    "label": "Pagination",
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {{current}} of {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Sign In",
     "converter": "Transmute - Workspace",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Arrastra un archivo, selecciona un formato, Transmute."
   },
+  "pagination": {
+    "label": "Paginación",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "pageOf": "Página {{current}} de {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Iniciar Sesión",
     "converter": "Transmute - Espacio de trabajo",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Déposer un fichier, choisir un format, Transmuter."
   },
+  "pagination": {
+    "label": "Pagination",
+    "previous": "Précédente",
+    "next": "Suivante",
+    "pageOf": "Page {{current}} sur {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Connexion",
     "converter": "Transmute - Espace de travail",

--- a/frontend/src/i18n/hi.json
+++ b/frontend/src/i18n/hi.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "फ़ाइल डालें, फ़ॉर्मेट चुनें, Transmute करें।"
   },
+  "pagination": {
+    "label": "पृष्ठ नेविगेशन",
+    "previous": "पिछला",
+    "next": "अगला",
+    "pageOf": "पृष्ठ {{current}} / {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - साइन इन",
     "converter": "Transmute - वर्कस्पेस",

--- a/frontend/src/i18n/it.json
+++ b/frontend/src/i18n/it.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Trascina un file, scegli un formato, Transmute."
   },
+  "pagination": {
+    "label": "Paginazione",
+    "previous": "Precedente",
+    "next": "Successiva",
+    "pageOf": "Pagina {{current}} di {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Accedi",
     "converter": "Transmute - Spazio di lavoro",

--- a/frontend/src/i18n/pl.json
+++ b/frontend/src/i18n/pl.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Upuść plik, wybierz format, konwertuj."
   },
+  "pagination": {
+    "label": "Stronicowanie",
+    "previous": "Poprzednia",
+    "next": "Następna",
+    "pageOf": "Strona {{current}} z {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Rejestracja",
     "converter": "Transmute - Obszar roboczy",

--- a/frontend/src/i18n/pt.json
+++ b/frontend/src/i18n/pt.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Solte um arquivo, escolha um formato, Transmute."
   },
+  "pagination": {
+    "label": "Paginação",
+    "previous": "Anterior",
+    "next": "Próxima",
+    "pageOf": "Página {{current}} de {{total}}"
+  },
   "titles": {
     "signIn": "Transmute - Entrar",
     "converter": "Transmute - Espaço de trabalho",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "Bir dosya bırakın, bir format seçin, Transmute."
   },
+  "pagination": {
+    "label": "Sayfalama",
+    "previous": "Önceki",
+    "next": "Sonraki",
+    "pageOf": "{{total}} sayfadan {{current}}. sayfa"
+  },
   "titles": {
     "signIn": "Transmute - Oturum Aç",
     "converter": "Transmute - Çalışma alanı",

--- a/frontend/src/i18n/zh-CN.json
+++ b/frontend/src/i18n/zh-CN.json
@@ -3,6 +3,12 @@
     "name": "Transmute",
     "tagline": "拖入文件，选择格式，开始转换。"
   },
+  "pagination": {
+    "label": "分页",
+    "previous": "上一页",
+    "next": "下一页",
+    "pageOf": "第 {{current}} 页，共 {{total}} 页"
+  },
   "titles": {
     "signIn": "Transmute - 登录",
     "converter": "Transmute - 工作区",

--- a/frontend/src/pages/Files.tsx
+++ b/frontend/src/pages/Files.tsx
@@ -1,9 +1,11 @@
-import { lazy, Suspense, useState, useEffect } from 'react'
+import { lazy, Suspense, useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import FileTable, { FileInfo } from '../components/FileTable'
 import { isPreviewable } from '../components/previewUtils'
 import { authFetch as fetch } from '../utils/api'
+import Pagination from '../components/Pagination'
+import { withPagination, type PaginationMetadata } from '../utils/pagination'
 
 const PreviewModal = lazy(() => import('../components/PreviewModal'))
 
@@ -15,24 +17,35 @@ function Files() {
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [deletingSelected, setDeletingSelected] = useState(false)
   const [previewFile, setPreviewFile] = useState<FileInfo | null>(null)
+  const [page, setPage] = useState(1)
+  const [pagination, setPagination] = useState<PaginationMetadata | null>(null)
   const navigate = useNavigate()
   const { t } = useTranslation()
 
-  useEffect(() => {
-    const fetchFiles = async () => {
-      try {
-        const response = await fetch('/api/files')
-        if (!response.ok) throw new Error(t('files.fetchFailed'))
-        const data = await response.json()
-        setFiles(data.files)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : t('files.loadFailed'))
-      } finally {
-        setLoading(false)
+  const fetchFiles = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch(withPagination('/api/files', page))
+      if (!response.ok) throw new Error(t('files.fetchFailed'))
+      const data = await response.json() as { files: FileInfo[]; pagination: PaginationMetadata }
+      if (data.pagination.total_pages > 0 && page > data.pagination.total_pages) {
+        setPage(data.pagination.total_pages)
+        return
       }
+      setFiles(data.files)
+      setPagination(data.pagination)
+      setSelectedIds(new Set())
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('files.loadFailed'))
+    } finally {
+      setLoading(false)
     }
-    fetchFiles()
-  }, [])
+  }, [page, t])
+
+  useEffect(() => {
+    void fetchFiles()
+  }, [fetchFiles])
 
   const handleDelete = async (fileId: string) => {
     setDeletingId(fileId)
@@ -45,6 +58,7 @@ function Files() {
         newSet.delete(fileId)
         return newSet
       })
+      await fetchFiles()
     } catch (err) {
       setError(err instanceof Error ? err.message : t('files.deleteFailed'))
     } finally {
@@ -100,6 +114,8 @@ function Files() {
       setError(errors.join('; '))
     }
 
+    await fetchFiles()
+
     setDeletingSelected(false)
   }
 
@@ -149,20 +165,29 @@ function Files() {
         )}
 
         {!loading && files.length > 0 && (
-          <FileTable
-            rows={files.map(file => ({
-              id: file.id,
-              file,
-              onDelete: () => handleDelete(file.id),
-              onPreview: isPreviewable(file.media_type) ? () => setPreviewFile(file) : undefined,
-              isDeleting: deletingId === file.id,
-            }))}
-            isPending={true}
-            showCheckbox={true}
-            selectedIds={selectedIds}
-            onToggleSelect={toggleSelection}
-            onToggleSelectAll={toggleSelectAll}
-          />
+          <>
+            <FileTable
+              rows={files.map(file => ({
+                id: file.id,
+                file,
+                onDelete: () => handleDelete(file.id),
+                onPreview: isPreviewable(file.media_type) ? () => setPreviewFile(file) : undefined,
+                isDeleting: deletingId === file.id,
+              }))}
+              isPending={true}
+              showCheckbox={true}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelection}
+              onToggleSelectAll={toggleSelectAll}
+            />
+            {pagination && (
+              <Pagination
+                pagination={pagination}
+                onPageChange={setPage}
+                disabled={loading || deletingSelected}
+              />
+            )}
+          </>
         )}
 
         {previewFile && (

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -6,6 +6,8 @@ import { authFetch as fetch } from '../utils/api'
 import { parseUtcTimestamp } from '../utils/datetime'
 import { downloadBlob } from '../utils/download'
 import { stripExtension } from '../utils/filename'
+import Pagination from '../components/Pagination'
+import { withPagination, type PaginationMetadata } from '../utils/pagination'
 import { cancelJob, deleteJob, listJobs, retryJob, isTerminalJobStatus, type ConversionJob,
   cancelCompressionJob, deleteCompressionJob, listCompressionJobs, retryCompressionJob, type CompressionJob } from '../utils/jobs'
 
@@ -62,38 +64,57 @@ function History() {
   const [deletingSelected, setDeletingSelected] = useState(false)
   const [downloadingSelected, setDownloadingSelected] = useState(false)
   const [previewConversion, setPreviewConversion] = useState<ConversionRecord | null>(null)
+  const [conversionPage, setConversionPage] = useState(1)
+  const [compressionPage, setCompressionPage] = useState(1)
+  const [conversionPagination, setConversionPagination] = useState<PaginationMetadata | null>(null)
+  const [compressionPagination, setCompressionPagination] = useState<PaginationMetadata | null>(null)
   const { t } = useTranslation()
   const isMountedRef = useRef(true)
 
   const refresh = useCallback(async () => {
     try {
       const [convResp, jobsList, compResp, compJobsList] = await Promise.all([
-        fetch('/api/conversions/complete'),
-        listJobs(),
-        fetch('/api/compressions/complete'),
-        listCompressionJobs(),
+        fetch(withPagination('/api/conversions/complete', conversionPage)),
+        listJobs(undefined, 1, 100, false),
+        fetch(withPagination('/api/compressions/complete', compressionPage)),
+        listCompressionJobs(undefined, 1, 100, false),
       ])
       if (!convResp.ok) throw new Error(t('history.fetchFailed'))
       if (!compResp.ok) throw new Error(t('history.fetchFailed'))
-      const convData = await convResp.json()
-      const compData = await compResp.json()
+      const convData = await convResp.json() as {
+        conversions: ConversionRecord[]
+        pagination: PaginationMetadata
+      }
+      const compData = await compResp.json() as {
+        compressions: CompressionRecord[]
+        pagination: PaginationMetadata
+      }
       if (!isMountedRef.current) return
       setConversions(convData.conversions)
       setCompressions(compData.compressions)
+      setConversionPagination(convData.pagination)
+      setCompressionPagination(compData.pagination)
+      if (conversionPage > Math.max(1, convData.pagination.total_pages)) {
+        setConversionPage(Math.max(1, convData.pagination.total_pages))
+      }
+      if (compressionPage > Math.max(1, compData.pagination.total_pages)) {
+        setCompressionPage(Math.max(1, compData.pagination.total_pages))
+      }
       // Hide completed jobs from the jobs list — the completed conversions
       // already represent them with full original-file metadata.
-      setJobs(jobsList.filter(j => j.status !== 'completed'))
-      setCompressionJobs(compJobsList.filter(j => j.status !== 'completed'))
+      setJobs(jobsList)
+      setCompressionJobs(compJobsList)
       setError(null)
     } catch (err) {
       if (isMountedRef.current) {
         setError(err instanceof Error ? err.message : t('history.loadFailed'))
       }
     }
-  }, [t])
+  }, [compressionPage, conversionPage, t])
 
   useEffect(() => {
     isMountedRef.current = true
+    setLoading(true)
     refresh().finally(() => {
       if (isMountedRef.current) setLoading(false)
     })
@@ -101,6 +122,10 @@ function History() {
       isMountedRef.current = false
     }
   }, [refresh])
+
+  useEffect(() => {
+    setSelectedIds(new Set())
+  }, [compressionPage, conversionPage])
 
   // Poll while at least one job is non-terminal.
   const hasActiveJobs = jobs.some(j => !isTerminalJobStatus(j.status))
@@ -135,6 +160,7 @@ function History() {
       const response = await fetch(`/api/conversions/${conversionId}`, { method: 'DELETE' })
       if (!response.ok) throw new Error(t('history.deleteFailed'))
       setConversions(prev => prev.filter(c => c.id !== conversionId))
+      await refresh()
     } catch (err) {
       setError(err instanceof Error ? err.message : t('history.deleteFailed'))
     } finally {
@@ -203,6 +229,7 @@ function History() {
       const response = await fetch(`/api/compressions/${compressionId}`, { method: 'DELETE' })
       if (!response.ok) throw new Error(t('history.deleteFailed'))
       setCompressions(prev => prev.filter(c => c.id !== compressionId))
+      await refresh()
     } catch (err) {
       setError(err instanceof Error ? err.message : t('history.deleteFailed'))
     } finally {
@@ -309,6 +336,8 @@ function History() {
     if (errors.length > 0) {
       setError(errors.join('; '))
     }
+
+    await refresh()
 
     setDeletingSelected(false)
   }
@@ -426,7 +455,7 @@ function History() {
     }
   })
 
-  const allRows = [...jobRows, ...conversionRows]
+  const allRows = conversionPage === 1 ? [...jobRows, ...conversionRows] : conversionRows
 
   // Compression job rows (non-completed compression jobs).
   const compressionJobRows: FileTableRow[] = compressionJobs
@@ -514,8 +543,11 @@ function History() {
     }
   })
 
-  const compressAllRows = [...compressionJobRows, ...compressionRows]
+  const compressAllRows = compressionPage === 1
+    ? [...compressionJobRows, ...compressionRows]
+    : compressionRows
   const displayedRows = mode === 'compress' ? compressAllRows : allRows
+  const displayedPagination = mode === 'compress' ? compressionPagination : conversionPagination
 
   return (
     <div className="min-h-full bg-gradient-to-br from-surface-dark to-surface-light p-8 pb-12">
@@ -584,15 +616,24 @@ function History() {
         )}
 
         {!loading && displayedRows.length > 0 && (
-          <FileTable
-            rows={displayedRows}
-            showCheckbox={true}
-            showStatus={true}
-            typeColumnLabel={mode === 'compress' ? t('table.compressionLevel') : undefined}
-            selectedIds={selectedIds}
-            onToggleSelect={toggleSelection}
-            onToggleSelectAll={toggleSelectAll}
-          />
+          <>
+            <FileTable
+              rows={displayedRows}
+              showCheckbox={true}
+              showStatus={true}
+              typeColumnLabel={mode === 'compress' ? t('table.compressionLevel') : undefined}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelection}
+              onToggleSelectAll={toggleSelectAll}
+            />
+            {displayedPagination && (
+              <Pagination
+                pagination={displayedPagination}
+                onPageChange={mode === 'compress' ? setCompressionPage : setConversionPage}
+                disabled={loading || deletingSelected}
+              />
+            )}
+          </>
         )}
 
         {previewConversion && (

--- a/frontend/src/utils/jobs.ts
+++ b/frontend/src/utils/jobs.ts
@@ -1,4 +1,5 @@
 import { authFetch, apiJson, ApiError } from './api'
+import { withPagination, type PaginationMetadata } from './pagination'
 
 export type ConversionJobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
 
@@ -31,6 +32,7 @@ export interface ConversionJob {
 
 export interface ConversionJobListResponse {
   jobs: ConversionJob[]
+  pagination: PaginationMetadata
 }
 
 export interface ConversionJobCreatePayload {
@@ -43,10 +45,19 @@ export function isTerminalJobStatus(status: ConversionJobStatus): boolean {
   return TERMINAL_JOB_STATUSES.has(status)
 }
 
-export async function listJobs(statusFilter?: ConversionJobStatus): Promise<ConversionJob[]> {
-  const url = statusFilter
+export async function listJobs(
+  statusFilter?: ConversionJobStatus,
+  page = 1,
+  pageSize = 100,
+  includeCompleted = true,
+): Promise<ConversionJob[]> {
+  let baseUrl = statusFilter
     ? `/api/jobs?status_filter=${encodeURIComponent(statusFilter)}`
     : '/api/jobs'
+  if (!includeCompleted && !statusFilter) {
+    baseUrl += '?include_completed=false'
+  }
+  const url = withPagination(baseUrl, page, pageSize)
   const data = await apiJson<ConversionJobListResponse>(url)
   return data.jobs
 }
@@ -130,6 +141,7 @@ export interface CompressionJob {
 
 export interface CompressionJobListResponse {
   jobs: CompressionJob[]
+  pagination: PaginationMetadata
 }
 
 export interface CompressionJobCreatePayload {
@@ -137,10 +149,19 @@ export interface CompressionJobCreatePayload {
   compression_level?: string | null
 }
 
-export async function listCompressionJobs(statusFilter?: ConversionJobStatus): Promise<CompressionJob[]> {
-  const url = statusFilter
+export async function listCompressionJobs(
+  statusFilter?: ConversionJobStatus,
+  page = 1,
+  pageSize = 100,
+  includeCompleted = true,
+): Promise<CompressionJob[]> {
+  let baseUrl = statusFilter
     ? `/api/compression-jobs?status_filter=${encodeURIComponent(statusFilter)}`
     : '/api/compression-jobs'
+  if (!includeCompleted && !statusFilter) {
+    baseUrl += '?include_completed=false'
+  }
+  const url = withPagination(baseUrl, page, pageSize)
   const data = await apiJson<CompressionJobListResponse>(url)
   return data.jobs
 }

--- a/frontend/src/utils/pagination.ts
+++ b/frontend/src/utils/pagination.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_PAGE_SIZE = 20
+
+export interface PaginationMetadata {
+  total_items: number
+  total_pages: number
+  current_page: number
+  page_size: number
+  has_next: boolean
+  has_prev: boolean
+}
+
+export function withPagination(url: string, page: number, pageSize = DEFAULT_PAGE_SIZE): string {
+  const separator = url.includes('?') ? '&' : '?'
+  return `${url}${separator}page=${page}&page_size=${pageSize}`
+}


### PR DESCRIPTION
## What

- Add `page` and `page_size` query parameters plus pagination metadata to the files, completed conversions/compressions, and job list APIs.
- Apply stable newest-first database pagination, count queries, and page-scoped relation lookups.
- Add reusable pagination controls to the Files and Jobs/History pages, including translations for every supported locale.
- Keep active and failed jobs visible on the first page while paginating completed history separately.

## Why

The Files and Jobs pages currently load every record in a single request. As histories grow, that increases response size, database work, and client rendering cost. API-backed pagination bounds that work while preserving the existing user-scoped behavior.

Closes #179

## Testing

- `python -m compileall -q api core db`
- Focused backend test suite: 45 passed
- `npm run build`
- Focused pagination and i18n Vitest suite: 7 passed
- ESLint on all changed frontend source files
- `npm run check:i18n`

The full frontend Vitest run completes all 20 assertions, but the current main-branch test setup reports an unrelated unhandled `window.matchMedia` error from `FormatDropdown`.

---

* [x] Tested locally
* [x] Docs updated if needed
