### PR TITLE
Feat: File pasting support

### DIFF
--- a/frontend/src/pages/Converter.test.tsx
+++ b/frontend/src/pages/Converter.test.tsx
@@ -69,8 +69,41 @@ function pasteText(dropZone: HTMLElement, text: string) {
   dispatchPaste(dropZone, dt)
 }
 
+function dispatchDrop(dropZone: HTMLElement, dt: DataTransfer) {
+  const event = new Event('drop', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', { value: dt })
+  fireEvent(dropZone, event)
+}
+
+function dropFiles(dropZone: HTMLElement, files: File[]) {
+  const dt = createDataTransfer(files)
+  dispatchDrop(dropZone, dt)
+}
+
+function dispatchDragOver(dropZone: HTMLElement) {
+  fireEvent(dropZone, new Event('dragover', { bubbles: true, cancelable: true }))
+}
+
+function dispatchDragLeave(dropZone: HTMLElement) {
+  fireEvent(dropZone, new Event('dragleave', { bubbles: true, cancelable: true }))
+}
+
+function selectFilesViaInput(input: HTMLInputElement, files: File[]) {
+  Object.defineProperty(input, 'files', { value: files, configurable: true })
+  Object.defineProperty(input, 'value', {
+    value: files.length > 0 ? `C:\\fakepath\\${files[0].name}` : '',
+    configurable: true,
+    writable: true,
+  })
+  fireEvent.change(input)
+}
+
 function findDropZone() {
   return screen.getByTestId('drop-zone')
+}
+
+function findFileInput() {
+  return document.querySelector('input[type="file"]') as HTMLInputElement
 }
 
 function makeUploadResponse(filename: string, id: string) {
@@ -97,7 +130,7 @@ function defaultFetchResponse(url: string): Response | undefined {
   return undefined
 }
 
-describe('Converter paste handling', () => {
+describe('Converter drop-zone interactions', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(async () => {
@@ -118,76 +151,196 @@ describe('Converter paste handling', () => {
     fetchSpy.mockRestore()
   })
 
-  it('uploads files pasted onto the drop zone', async () => {
-    renderConverter()
+  describe('paste handling', () => {
+    it('uploads files pasted onto the drop zone', async () => {
+      renderConverter()
 
-    const file = new File(['hello world'], 'pasted.txt', { type: 'text/plain' })
-    pasteFiles(findDropZone(), [file])
+      const file = new File(['hello world'], 'pasted.txt', { type: 'text/plain' })
+      pasteFiles(findDropZone(), [file])
 
-    await screen.findByText('pasted.txt')
-    expect(screen.getByText('pasted.txt')).toBeInTheDocument()
+      await screen.findByText('pasted.txt')
+      expect(screen.getByText('pasted.txt')).toBeInTheDocument()
 
-    const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-      urlMatchesPath(input, '/api/files'),
-    )
-    expect(fileCalls).toHaveLength(1)
+      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+        urlMatchesPath(input, '/api/files'),
+      )
+      expect(fileCalls).toHaveLength(1)
 
-    const [, init] = fileCalls[0]
-    expect(init?.method).toBe('POST')
-    expect(init?.body).toBeInstanceOf(FormData)
-  })
-
-  it('ignores pasted files while an upload is already in progress', async () => {
-    let resolveUpload: (value: Response) => void
-    const uploadPromise = new Promise<Response>((resolve) => {
-      resolveUpload = resolve
+      const [, init] = fileCalls[0]
+      expect(init?.method).toBe('POST')
+      expect(init?.body).toBeInstanceOf(FormData)
     })
 
-    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = urlFromFetchInput(input)
-      if (urlMatchesPath(input, '/api/files')) return uploadPromise
-      const defaultResponse = defaultFetchResponse(url)
-      if (defaultResponse) return defaultResponse
-      return new Response(null, { status: 404 })
+    it('ignores pasted files while an upload is already in progress', async () => {
+      let resolveUpload: (value: Response) => void
+      const uploadPromise = new Promise<Response>((resolve) => {
+        resolveUpload = resolve
+      })
+
+      fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+        const url = urlFromFetchInput(input)
+        if (urlMatchesPath(input, '/api/files')) return uploadPromise
+        const defaultResponse = defaultFetchResponse(url)
+        if (defaultResponse) return defaultResponse
+        return new Response(null, { status: 404 })
+      })
+
+      renderConverter()
+
+      const firstFile = new File(['first'], 'first.txt', { type: 'text/plain' })
+      pasteFiles(findDropZone(), [firstFile])
+
+      const secondFile = new File(['second'], 'second.txt', { type: 'text/plain' })
+      pasteFiles(findDropZone(), [secondFile])
+
+      const fileCallsBeforeResolve = fetchSpy.mock.calls.filter(
+        ([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files'),
+      )
+      expect(fileCallsBeforeResolve).toHaveLength(1)
+
+      resolveUpload!(new Response(JSON.stringify(makeUploadResponse('first.txt', 'file-1')), { status: 200 }))
     })
 
-    renderConverter()
+    it('ignores an empty paste', async () => {
+      renderConverter()
+      pasteFiles(findDropZone(), [])
 
-    const firstFile = new File(['first'], 'first.txt', { type: 'text/plain' })
-    pasteFiles(findDropZone(), [firstFile])
+      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+        urlMatchesPath(input, '/api/files'),
+      )
+      expect(fileCalls).toHaveLength(0)
+    })
 
-    const secondFile = new File(['second'], 'second.txt', { type: 'text/plain' })
-    pasteFiles(findDropZone(), [secondFile])
+    it('ignores pasted plain text in the drop zone', async () => {
+      renderConverter()
+      pasteText(findDropZone(), 'https://example.com/file.txt')
 
-    const fileCallsBeforeResolve = fetchSpy.mock.calls.filter(
-      ([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files'),
-    )
-    expect(fileCallsBeforeResolve).toHaveLength(1)
-
-    resolveUpload!(new Response(JSON.stringify(makeUploadResponse('first.txt', 'file-1')), { status: 200 }))
+      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+        urlMatchesPath(input, '/api/files'),
+      )
+      const urlCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+        urlMatchesPath(input, '/api/files/url'),
+      )
+      expect(fileCalls).toHaveLength(0)
+      expect(urlCalls).toHaveLength(0)
+    })
   })
 
-  it('ignores an empty paste', async () => {
-    renderConverter()
-    pasteFiles(findDropZone(), [])
+  describe('drag-and-drop handling', () => {
+    it('uploads files dropped onto the drop zone', async () => {
+      renderConverter()
 
-    const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-      urlMatchesPath(input, '/api/files'),
-    )
-    expect(fileCalls).toHaveLength(0)
+      const file = new File(['hello world'], 'dropped.txt', { type: 'text/plain' })
+      dropFiles(findDropZone(), [file])
+
+      await screen.findByText('dropped.txt')
+      expect(screen.getByText('dropped.txt')).toBeInTheDocument()
+
+      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+        urlMatchesPath(input, '/api/files'),
+      )
+      expect(fileCalls).toHaveLength(1)
+
+      const [, init] = fileCalls[0]
+      expect(init?.method).toBe('POST')
+      expect(init?.body).toBeInstanceOf(FormData)
+    })
+
+    it('enters then exits the drag-over highlight across dragover/dragleave', () => {
+      renderConverter()
+      const dropZone = findDropZone()
+
+      dispatchDragOver(dropZone)
+      expect(dropZone.className).toContain('bg-primary/10')
+
+      dispatchDragLeave(dropZone)
+      expect(dropZone.className).not.toContain('bg-primary/10')
+    })
+
+    it('clears the drag-over highlight after a drop', async () => {
+      renderConverter()
+      const dropZone = findDropZone()
+
+      dispatchDragOver(dropZone)
+      expect(dropZone.className).toContain('bg-primary/10')
+
+      const file = new File(['hello world'], 'dropped.txt', { type: 'text/plain' })
+      dropFiles(dropZone, [file])
+
+      await screen.findByText('dropped.txt')
+      expect(dropZone.className).not.toContain('bg-primary/10')
+    })
+
+    it('ignores drops while an upload is already in progress', async () => {
+      let resolveUpload: (value: Response) => void
+      const uploadPromise = new Promise<Response>((resolve) => {
+        resolveUpload = resolve
+      })
+
+      fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+        const url = urlFromFetchInput(input)
+        if (urlMatchesPath(input, '/api/files')) return uploadPromise
+        const defaultResponse = defaultFetchResponse(url)
+        if (defaultResponse) return defaultResponse
+        return new Response(null, { status: 404 })
+      })
+
+      renderConverter()
+
+      const firstFile = new File(['first'], 'first.txt', { type: 'text/plain' })
+      dropFiles(findDropZone(), [firstFile])
+
+      const secondFile = new File(['second'], 'second.txt', { type: 'text/plain' })
+      dropFiles(findDropZone(), [secondFile])
+
+      const fileCallsBeforeResolve = fetchSpy.mock.calls.filter(
+        ([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files'),
+      )
+      expect(fileCallsBeforeResolve).toHaveLength(1)
+
+      resolveUpload!(new Response(JSON.stringify(makeUploadResponse('first.txt', 'file-1')), { status: 200 }))
+    })
   })
 
-  it('ignores pasted plain text in the drop zone', async () => {
-    renderConverter()
-    pasteText(findDropZone(), 'https://example.com/file.txt')
+  describe('file-select handling', () => {
+    it('uploads files chosen via the hidden file input', async () => {
+      renderConverter()
 
-    const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-      urlMatchesPath(input, '/api/files'),
-    )
-    const urlCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-      urlMatchesPath(input, '/api/files/url'),
-    )
-    expect(fileCalls).toHaveLength(0)
-    expect(urlCalls).toHaveLength(0)
+      const file = new File(['hello world'], 'chosen.txt', { type: 'text/plain' })
+      selectFilesViaInput(findFileInput(), [file])
+
+      await screen.findByText('chosen.txt')
+      expect(screen.getByText('chosen.txt')).toBeInTheDocument()
+
+      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+        urlMatchesPath(input, '/api/files'),
+      )
+      expect(fileCalls).toHaveLength(1)
+
+      const [, init] = fileCalls[0]
+      expect(init?.method).toBe('POST')
+      expect(init?.body).toBeInstanceOf(FormData)
+    })
+
+    it('ignores an empty file selection', async () => {
+      renderConverter()
+      selectFilesViaInput(findFileInput(), [])
+
+      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+        urlMatchesPath(input, '/api/files'),
+      )
+      expect(fileCalls).toHaveLength(0)
+    })
+
+    it('clears the input value after a successful selection', async () => {
+      renderConverter()
+      const input = findFileInput()
+
+      const file = new File(['hello world'], 'chosen.txt', { type: 'text/plain' })
+      selectFilesViaInput(input, [file])
+
+      await screen.findByText('chosen.txt')
+      expect(input.value).toBe('')
+    })
   })
 })

--- a/frontend/src/pages/Converter.test.tsx
+++ b/frontend/src/pages/Converter.test.tsx
@@ -56,10 +56,10 @@ function createDataTransfer(files: File[] = [], text = '', opts: { populateItems
   return dt as unknown as DataTransfer
 }
 
-function dispatchPaste(dropZone: HTMLElement, dt: DataTransfer) {
+function dispatchPaste(dt: DataTransfer) {
   const event = new Event('paste', { bubbles: true })
   Object.defineProperty(event, 'clipboardData', { value: dt })
-  fireEvent(dropZone, event)
+  fireEvent(document.body, event)
 }
 
 function dispatchDrop(dropZone: HTMLElement, dt: DataTransfer) {
@@ -68,10 +68,10 @@ function dispatchDrop(dropZone: HTMLElement, dt: DataTransfer) {
   fireEvent(dropZone, event)
 }
 
-const pasteFiles = (dropZone: HTMLElement, files: File[]) => dispatchPaste(dropZone, createDataTransfer(files))
-const pasteItems = (dropZone: HTMLElement, files: File[]) =>
-  dispatchPaste(dropZone, createDataTransfer(files, '', { populateItemsFromFiles: true, itemsOnly: true }))
-const pasteText = (dropZone: HTMLElement, text: string) => dispatchPaste(dropZone, createDataTransfer([], text))
+const pasteFiles = (files: File[]) => dispatchPaste(createDataTransfer(files))
+const pasteItems = (files: File[]) =>
+  dispatchPaste(createDataTransfer(files, '', { populateItemsFromFiles: true, itemsOnly: true }))
+const pasteText = (text: string) => dispatchPaste(createDataTransfer([], text))
 const dropFiles = (dropZone: HTMLElement, files: File[]) => dispatchDrop(dropZone, createDataTransfer(files))
 
 function selectFilesViaInput(input: HTMLInputElement, files: File[]) {
@@ -84,7 +84,7 @@ function selectFilesViaInput(input: HTMLInputElement, files: File[]) {
   fireEvent.change(input)
 }
 
-const findDropZone = () => screen.getByTestId('drop-zone')
+const findDropZone = () => document.querySelector('input[type="file"]')!.closest('label')!
 const findFileInput = () => document.querySelector('input[type="file"]') as HTMLInputElement
 
 function makeUploadResponse(filename: string, id: string) {
@@ -148,7 +148,7 @@ describe('Converter drop-zone interactions', () => {
   describe('paste handling', () => {
     it('uploads pasted files via POST with a FormData body', async () => {
       renderConverter()
-      pasteFiles(findDropZone(), [new File(['hello world'], 'pasted.txt', { type: 'text/plain' })])
+      pasteFiles([new File(['hello world'], 'pasted.txt', { type: 'text/plain' })])
 
       await screen.findByText('pasted.txt')
       const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files'))
@@ -160,7 +160,7 @@ describe('Converter drop-zone interactions', () => {
 
     it('uploads screenshot-style image blobs surfaced only via clipboard.items', async () => {
       renderConverter()
-      pasteItems(findDropZone(), [new File([new Uint8Array([1, 2, 3, 4])], 'image.png', { type: 'image/png' })])
+      pasteItems([new File([new Uint8Array([1, 2, 3, 4])], 'image.png', { type: 'image/png' })])
 
       await screen.findByText('pasted.txt')
       expect(fileUploadCount()).toBe(1)
@@ -169,7 +169,7 @@ describe('Converter drop-zone interactions', () => {
     it('de-duplicates when the same file appears in both clipboard.files and clipboard.items', async () => {
       renderConverter()
       const file = new File(['hello world'], 'shared.txt', { type: 'text/plain' })
-      dispatchPaste(findDropZone(), createDataTransfer([file], '', { populateItemsFromFiles: true }))
+      dispatchPaste(createDataTransfer([file], '', { populateItemsFromFiles: true }))
 
       await screen.findByText('pasted.txt')
       expect(fileUploadCount()).toBe(1)
@@ -177,8 +177,8 @@ describe('Converter drop-zone interactions', () => {
 
     it('ignores empty and text-only pastes (no file or URL upload)', async () => {
       renderConverter()
-      pasteFiles(findDropZone(), [])
-      pasteText(findDropZone(), 'https://example.com/file.txt')
+      pasteFiles([])
+      pasteText('https://example.com/file.txt')
 
       expect(fileUploadCount()).toBe(0)
       expect(fetchSpy.mock.calls.some(([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files/url'))).toBe(false)
@@ -188,8 +188,8 @@ describe('Converter drop-zone interactions', () => {
       const resolveUpload = stallFileUpload()
       renderConverter()
 
-      pasteFiles(findDropZone(), [new File(['first'], 'first.txt', { type: 'text/plain' })])
-      pasteFiles(findDropZone(), [new File(['second'], 'second.txt', { type: 'text/plain' })])
+      pasteFiles([new File(['first'], 'first.txt', { type: 'text/plain' })])
+      pasteFiles([new File(['second'], 'second.txt', { type: 'text/plain' })])
 
       expect(fileUploadCount()).toBe(2)
       resolveUpload()

--- a/frontend/src/pages/Converter.test.tsx
+++ b/frontend/src/pages/Converter.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import i18n from '../i18n'
+import Converter from './Converter'
+
+function renderConverter() {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <MemoryRouter>
+        <Converter />
+      </MemoryRouter>
+    </I18nextProvider>,
+  )
+}
+
+function urlFromFetchInput(input: RequestInfo | URL) {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.toString()
+  return input.url
+}
+
+function urlMatchesPath(input: RequestInfo | URL, path: string) {
+  const url = urlFromFetchInput(input)
+  return url === path || url.endsWith(path)
+}
+
+function createDataTransfer(files: File[] = [], text = '') {
+  // jsdom does not expose a working global DataTransfer constructor, so build a minimal stub.
+  const fileList = [...files]
+  const items: { kind: string; type: string; file?: File }[] = []
+  const dt = {
+    files: Object.assign(fileList, {
+      length: fileList.length,
+      item(i: number) { return fileList[i] ?? null },
+    }) as unknown as FileList,
+    items: {
+      add(file: File) {
+        fileList.push(file)
+        items.push({ kind: 'file', type: file.type, file })
+        return null
+      },
+      get length() { return items.length },
+    },
+    getData(type: string) {
+      return type === 'text/plain' ? text : ''
+    },
+    setData(type: string, value: string) {
+      if (type === 'text/plain') text = value
+    },
+  }
+  return dt as unknown as DataTransfer
+}
+
+function dispatchPaste(dropZone: HTMLElement, dt: DataTransfer) {
+  const event = new Event('paste', { bubbles: true })
+  Object.defineProperty(event, 'clipboardData', { value: dt })
+  fireEvent(dropZone, event)
+}
+
+function pasteFiles(dropZone: HTMLElement, files: File[]) {
+  const dt = createDataTransfer(files)
+  dispatchPaste(dropZone, dt)
+}
+
+function pasteText(dropZone: HTMLElement, text: string) {
+  const dt = createDataTransfer([], text)
+  dispatchPaste(dropZone, dt)
+}
+
+function findDropZone() {
+  return screen.getByTestId('drop-zone')
+}
+
+function makeUploadResponse(filename: string, id: string) {
+  return {
+    metadata: {
+      id,
+      original_filename: filename,
+      media_type: 'text',
+      extension: '.txt',
+      size_bytes: 12,
+      created_at: '2026-07-25T00:00:00Z',
+      compatible_formats: { txt: ['md'] },
+    },
+  }
+}
+
+function defaultFetchResponse(url: string): Response | undefined {
+  if (url === '/api/settings') return new Response(JSON.stringify({ auto_download: false }), { status: 200 })
+  if (url === '/api/default-formats') return new Response(JSON.stringify({ defaults: [], aliases: {} }), { status: 200 })
+  if (url === '/api/default-qualities') return new Response(JSON.stringify({ defaults: [] }), { status: 200 })
+  if (url === '/api/compressors') return new Response(JSON.stringify({ compressors: [] }), { status: 200 })
+  if (url === '/api/default-compression-levels') return new Response(JSON.stringify({ defaults: [] }), { status: 200 })
+  if (url === '/api/files/url') return new Response(JSON.stringify({ files: [] }), { status: 200 })
+  return undefined
+}
+
+describe('Converter paste handling', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(async (input) => {
+      const url = urlFromFetchInput(input)
+      const defaultResponse = defaultFetchResponse(url)
+      if (defaultResponse) return defaultResponse
+      if (urlMatchesPath(input, '/api/files')) {
+        return new Response(JSON.stringify(makeUploadResponse('pasted.txt', 'file-1')), { status: 200 })
+      }
+      return new Response(null, { status: 404 })
+    })
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('uploads files pasted onto the drop zone', async () => {
+    renderConverter()
+
+    const file = new File(['hello world'], 'pasted.txt', { type: 'text/plain' })
+    pasteFiles(findDropZone(), [file])
+
+    await screen.findByText('pasted.txt')
+    expect(screen.getByText('pasted.txt')).toBeInTheDocument()
+
+    const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+      urlMatchesPath(input, '/api/files'),
+    )
+    expect(fileCalls).toHaveLength(1)
+
+    const [, init] = fileCalls[0]
+    expect(init?.method).toBe('POST')
+    expect(init?.body).toBeInstanceOf(FormData)
+  })
+
+  it('ignores pasted files while an upload is already in progress', async () => {
+    let resolveUpload: (value: Response) => void
+    const uploadPromise = new Promise<Response>((resolve) => {
+      resolveUpload = resolve
+    })
+
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = urlFromFetchInput(input)
+      if (urlMatchesPath(input, '/api/files')) return uploadPromise
+      const defaultResponse = defaultFetchResponse(url)
+      if (defaultResponse) return defaultResponse
+      return new Response(null, { status: 404 })
+    })
+
+    renderConverter()
+
+    const firstFile = new File(['first'], 'first.txt', { type: 'text/plain' })
+    pasteFiles(findDropZone(), [firstFile])
+
+    const secondFile = new File(['second'], 'second.txt', { type: 'text/plain' })
+    pasteFiles(findDropZone(), [secondFile])
+
+    const fileCallsBeforeResolve = fetchSpy.mock.calls.filter(
+      ([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files'),
+    )
+    expect(fileCallsBeforeResolve).toHaveLength(1)
+
+    resolveUpload!(new Response(JSON.stringify(makeUploadResponse('first.txt', 'file-1')), { status: 200 }))
+  })
+
+  it('ignores an empty paste', async () => {
+    renderConverter()
+    pasteFiles(findDropZone(), [])
+
+    const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+      urlMatchesPath(input, '/api/files'),
+    )
+    expect(fileCalls).toHaveLength(0)
+  })
+
+  it('ignores pasted plain text in the drop zone', async () => {
+    renderConverter()
+    pasteText(findDropZone(), 'https://example.com/file.txt')
+
+    const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+      urlMatchesPath(input, '/api/files'),
+    )
+    const urlCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
+      urlMatchesPath(input, '/api/files/url'),
+    )
+    expect(fileCalls).toHaveLength(0)
+    expect(urlCalls).toHaveLength(0)
+  })
+})

--- a/frontend/src/pages/Converter.test.tsx
+++ b/frontend/src/pages/Converter.test.tsx
@@ -26,29 +26,32 @@ function urlMatchesPath(input: RequestInfo | URL, path: string) {
   return url === path || url.endsWith(path)
 }
 
-function createDataTransfer(files: File[] = [], text = '') {
-  // jsdom does not expose a working global DataTransfer constructor, so build a minimal stub.
-  const fileList = [...files]
-  const items: { kind: string; type: string; file?: File }[] = []
+function createDataTransfer(files: File[] = [], text = '', opts: { populateItemsFromFiles?: boolean; itemsOnly?: boolean } = {}) {
+  const fileList = opts.itemsOnly ? [] : [...files]
+  const items: { kind: string; type: string; file?: File; getAsFile?: () => File | null }[] = []
+  const itemsList: { add(file: File): null; length: number; [Symbol.iterator](): Iterator<typeof items[number]> } = {
+    add(file: File) {
+      fileList.push(file)
+      items.push({ kind: 'file', type: file.type, file, getAsFile: () => file })
+      return null
+    },
+    get length() { return items.length },
+    [Symbol.iterator]() { return items[Symbol.iterator]() },
+  }
   const dt = {
     files: Object.assign(fileList, {
       length: fileList.length,
       item(i: number) { return fileList[i] ?? null },
     }) as unknown as FileList,
-    items: {
-      add(file: File) {
-        fileList.push(file)
-        items.push({ kind: 'file', type: file.type, file })
-        return null
-      },
-      get length() { return items.length },
-    },
-    getData(type: string) {
-      return type === 'text/plain' ? text : ''
-    },
-    setData(type: string, value: string) {
-      if (type === 'text/plain') text = value
-    },
+    items: itemsList as unknown as DataTransferItemList,
+    getData(type: string) { return type === 'text/plain' ? text : '' },
+    setData(type: string, value: string) { if (type === 'text/plain') text = value },
+  }
+
+  if (opts.populateItemsFromFiles) {
+    for (const file of files) {
+      items.push({ kind: 'file', type: file.type, file, getAsFile: () => file })
+    }
   }
   return dt as unknown as DataTransfer
 }
@@ -59,34 +62,17 @@ function dispatchPaste(dropZone: HTMLElement, dt: DataTransfer) {
   fireEvent(dropZone, event)
 }
 
-function pasteFiles(dropZone: HTMLElement, files: File[]) {
-  const dt = createDataTransfer(files)
-  dispatchPaste(dropZone, dt)
-}
-
-function pasteText(dropZone: HTMLElement, text: string) {
-  const dt = createDataTransfer([], text)
-  dispatchPaste(dropZone, dt)
-}
-
 function dispatchDrop(dropZone: HTMLElement, dt: DataTransfer) {
   const event = new Event('drop', { bubbles: true, cancelable: true })
   Object.defineProperty(event, 'dataTransfer', { value: dt })
   fireEvent(dropZone, event)
 }
 
-function dropFiles(dropZone: HTMLElement, files: File[]) {
-  const dt = createDataTransfer(files)
-  dispatchDrop(dropZone, dt)
-}
-
-function dispatchDragOver(dropZone: HTMLElement) {
-  fireEvent(dropZone, new Event('dragover', { bubbles: true, cancelable: true }))
-}
-
-function dispatchDragLeave(dropZone: HTMLElement) {
-  fireEvent(dropZone, new Event('dragleave', { bubbles: true, cancelable: true }))
-}
+const pasteFiles = (dropZone: HTMLElement, files: File[]) => dispatchPaste(dropZone, createDataTransfer(files))
+const pasteItems = (dropZone: HTMLElement, files: File[]) =>
+  dispatchPaste(dropZone, createDataTransfer(files, '', { populateItemsFromFiles: true, itemsOnly: true }))
+const pasteText = (dropZone: HTMLElement, text: string) => dispatchPaste(dropZone, createDataTransfer([], text))
+const dropFiles = (dropZone: HTMLElement, files: File[]) => dispatchDrop(dropZone, createDataTransfer(files))
 
 function selectFilesViaInput(input: HTMLInputElement, files: File[]) {
   Object.defineProperty(input, 'files', { value: files, configurable: true })
@@ -98,13 +84,8 @@ function selectFilesViaInput(input: HTMLInputElement, files: File[]) {
   fireEvent.change(input)
 }
 
-function findDropZone() {
-  return screen.getByTestId('drop-zone')
-}
-
-function findFileInput() {
-  return document.querySelector('input[type="file"]') as HTMLInputElement
-}
+const findDropZone = () => screen.getByTestId('drop-zone')
+const findFileInput = () => document.querySelector('input[type="file"]') as HTMLInputElement
 
 function makeUploadResponse(filename: string, id: string) {
   return {
@@ -135,7 +116,6 @@ describe('Converter drop-zone interactions', () => {
 
   beforeEach(async () => {
     await i18n.changeLanguage('en')
-
     fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(async (input) => {
       const url = urlFromFetchInput(input)
       const defaultResponse = defaultFetchResponse(url)
@@ -147,113 +127,92 @@ describe('Converter drop-zone interactions', () => {
     })
   })
 
-  afterEach(() => {
-    fetchSpy.mockRestore()
-  })
+  afterEach(() => { fetchSpy.mockRestore() })
+
+  const fileUploadCount = () =>
+    fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files')).length
+
+  function stallFileUpload() {
+    let resolveUpload!: (value: Response) => void
+    const uploadPromise = new Promise<Response>((resolve) => { resolveUpload = resolve })
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = urlFromFetchInput(input)
+      if (urlMatchesPath(input, '/api/files')) return uploadPromise
+      const r = defaultFetchResponse(url)
+      if (r) return r
+      return new Response(null, { status: 404 })
+    })
+    return () => resolveUpload(new Response(JSON.stringify(makeUploadResponse('first.txt', 'file-1')), { status: 200 }))
+  }
 
   describe('paste handling', () => {
-    it('uploads files pasted onto the drop zone', async () => {
+    it('uploads pasted files via POST with a FormData body', async () => {
       renderConverter()
-
-      const file = new File(['hello world'], 'pasted.txt', { type: 'text/plain' })
-      pasteFiles(findDropZone(), [file])
+      pasteFiles(findDropZone(), [new File(['hello world'], 'pasted.txt', { type: 'text/plain' })])
 
       await screen.findByText('pasted.txt')
-      expect(screen.getByText('pasted.txt')).toBeInTheDocument()
-
-      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-        urlMatchesPath(input, '/api/files'),
-      )
+      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files'))
       expect(fileCalls).toHaveLength(1)
-
       const [, init] = fileCalls[0]
       expect(init?.method).toBe('POST')
       expect(init?.body).toBeInstanceOf(FormData)
     })
 
-    it('ignores pasted files while an upload is already in progress', async () => {
-      let resolveUpload: (value: Response) => void
-      const uploadPromise = new Promise<Response>((resolve) => {
-        resolveUpload = resolve
-      })
-
-      fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
-        const url = urlFromFetchInput(input)
-        if (urlMatchesPath(input, '/api/files')) return uploadPromise
-        const defaultResponse = defaultFetchResponse(url)
-        if (defaultResponse) return defaultResponse
-        return new Response(null, { status: 404 })
-      })
-
+    it('uploads screenshot-style image blobs surfaced only via clipboard.items', async () => {
       renderConverter()
+      pasteItems(findDropZone(), [new File([new Uint8Array([1, 2, 3, 4])], 'image.png', { type: 'image/png' })])
 
-      const firstFile = new File(['first'], 'first.txt', { type: 'text/plain' })
-      pasteFiles(findDropZone(), [firstFile])
-
-      const secondFile = new File(['second'], 'second.txt', { type: 'text/plain' })
-      pasteFiles(findDropZone(), [secondFile])
-
-      const fileCallsBeforeResolve = fetchSpy.mock.calls.filter(
-        ([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files'),
-      )
-      expect(fileCallsBeforeResolve).toHaveLength(1)
-
-      resolveUpload!(new Response(JSON.stringify(makeUploadResponse('first.txt', 'file-1')), { status: 200 }))
+      await screen.findByText('pasted.txt')
+      expect(fileUploadCount()).toBe(1)
     })
 
-    it('ignores an empty paste', async () => {
+    it('de-duplicates when the same file appears in both clipboard.files and clipboard.items', async () => {
+      renderConverter()
+      const file = new File(['hello world'], 'shared.txt', { type: 'text/plain' })
+      dispatchPaste(findDropZone(), createDataTransfer([file], '', { populateItemsFromFiles: true }))
+
+      await screen.findByText('pasted.txt')
+      expect(fileUploadCount()).toBe(1)
+    })
+
+    it('ignores empty and text-only pastes (no file or URL upload)', async () => {
       renderConverter()
       pasteFiles(findDropZone(), [])
-
-      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-        urlMatchesPath(input, '/api/files'),
-      )
-      expect(fileCalls).toHaveLength(0)
-    })
-
-    it('ignores pasted plain text in the drop zone', async () => {
-      renderConverter()
       pasteText(findDropZone(), 'https://example.com/file.txt')
 
-      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-        urlMatchesPath(input, '/api/files'),
-      )
-      const urlCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-        urlMatchesPath(input, '/api/files/url'),
-      )
-      expect(fileCalls).toHaveLength(0)
-      expect(urlCalls).toHaveLength(0)
+      expect(fileUploadCount()).toBe(0)
+      expect(fetchSpy.mock.calls.some(([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files/url'))).toBe(false)
+    })
+
+    it('ignores pasted files while an upload is already in progress', async () => {
+      const resolveUpload = stallFileUpload()
+      renderConverter()
+
+      pasteFiles(findDropZone(), [new File(['first'], 'first.txt', { type: 'text/plain' })])
+      pasteFiles(findDropZone(), [new File(['second'], 'second.txt', { type: 'text/plain' })])
+
+      expect(fileUploadCount()).toBe(1)
+      resolveUpload()
     })
   })
 
   describe('drag-and-drop handling', () => {
     it('uploads files dropped onto the drop zone', async () => {
       renderConverter()
-
-      const file = new File(['hello world'], 'dropped.txt', { type: 'text/plain' })
-      dropFiles(findDropZone(), [file])
+      dropFiles(findDropZone(), [new File(['hello world'], 'dropped.txt', { type: 'text/plain' })])
 
       await screen.findByText('dropped.txt')
-      expect(screen.getByText('dropped.txt')).toBeInTheDocument()
-
-      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-        urlMatchesPath(input, '/api/files'),
-      )
-      expect(fileCalls).toHaveLength(1)
-
-      const [, init] = fileCalls[0]
-      expect(init?.method).toBe('POST')
-      expect(init?.body).toBeInstanceOf(FormData)
+      expect(fileUploadCount()).toBe(1)
     })
 
-    it('enters then exits the drag-over highlight across dragover/dragleave', () => {
+    it('toggles the drag-over highlight across dragover/dragleave', () => {
       renderConverter()
       const dropZone = findDropZone()
 
-      dispatchDragOver(dropZone)
+      fireEvent(dropZone, new Event('dragover', { bubbles: true, cancelable: true }))
       expect(dropZone.className).toContain('bg-primary/10')
 
-      dispatchDragLeave(dropZone)
+      fireEvent(dropZone, new Event('dragleave', { bubbles: true }))
       expect(dropZone.className).not.toContain('bg-primary/10')
     })
 
@@ -261,86 +220,29 @@ describe('Converter drop-zone interactions', () => {
       renderConverter()
       const dropZone = findDropZone()
 
-      dispatchDragOver(dropZone)
+      fireEvent(dropZone, new Event('dragover', { bubbles: true, cancelable: true }))
       expect(dropZone.className).toContain('bg-primary/10')
 
-      const file = new File(['hello world'], 'dropped.txt', { type: 'text/plain' })
-      dropFiles(dropZone, [file])
-
+      dropFiles(dropZone, [new File(['hello world'], 'dropped.txt', { type: 'text/plain' })])
       await screen.findByText('dropped.txt')
       expect(dropZone.className).not.toContain('bg-primary/10')
-    })
-
-    it('ignores drops while an upload is already in progress', async () => {
-      let resolveUpload: (value: Response) => void
-      const uploadPromise = new Promise<Response>((resolve) => {
-        resolveUpload = resolve
-      })
-
-      fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
-        const url = urlFromFetchInput(input)
-        if (urlMatchesPath(input, '/api/files')) return uploadPromise
-        const defaultResponse = defaultFetchResponse(url)
-        if (defaultResponse) return defaultResponse
-        return new Response(null, { status: 404 })
-      })
-
-      renderConverter()
-
-      const firstFile = new File(['first'], 'first.txt', { type: 'text/plain' })
-      dropFiles(findDropZone(), [firstFile])
-
-      const secondFile = new File(['second'], 'second.txt', { type: 'text/plain' })
-      dropFiles(findDropZone(), [secondFile])
-
-      const fileCallsBeforeResolve = fetchSpy.mock.calls.filter(
-        ([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files'),
-      )
-      expect(fileCallsBeforeResolve).toHaveLength(1)
-
-      resolveUpload!(new Response(JSON.stringify(makeUploadResponse('first.txt', 'file-1')), { status: 200 }))
     })
   })
 
   describe('file-select handling', () => {
-    it('uploads files chosen via the hidden file input', async () => {
+    it('uploads files chosen via the hidden file input and clears the input', async () => {
       renderConverter()
-
-      const file = new File(['hello world'], 'chosen.txt', { type: 'text/plain' })
-      selectFilesViaInput(findFileInput(), [file])
+      selectFilesViaInput(findFileInput(), [new File(['hello world'], 'chosen.txt', { type: 'text/plain' })])
 
       await screen.findByText('chosen.txt')
-      expect(screen.getByText('chosen.txt')).toBeInTheDocument()
-
-      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-        urlMatchesPath(input, '/api/files'),
-      )
-      expect(fileCalls).toHaveLength(1)
-
-      const [, init] = fileCalls[0]
-      expect(init?.method).toBe('POST')
-      expect(init?.body).toBeInstanceOf(FormData)
+      expect(fileUploadCount()).toBe(1)
+      expect(findFileInput().value).toBe('')
     })
 
     it('ignores an empty file selection', async () => {
       renderConverter()
       selectFilesViaInput(findFileInput(), [])
-
-      const fileCalls = fetchSpy.mock.calls.filter(([input]: [RequestInfo | URL]) =>
-        urlMatchesPath(input, '/api/files'),
-      )
-      expect(fileCalls).toHaveLength(0)
-    })
-
-    it('clears the input value after a successful selection', async () => {
-      renderConverter()
-      const input = findFileInput()
-
-      const file = new File(['hello world'], 'chosen.txt', { type: 'text/plain' })
-      selectFilesViaInput(input, [file])
-
-      await screen.findByText('chosen.txt')
-      expect(input.value).toBe('')
+      expect(fileUploadCount()).toBe(0)
     })
   })
 })

--- a/frontend/src/pages/Converter.test.tsx
+++ b/frontend/src/pages/Converter.test.tsx
@@ -184,14 +184,14 @@ describe('Converter drop-zone interactions', () => {
       expect(fetchSpy.mock.calls.some(([input]: [RequestInfo | URL]) => urlMatchesPath(input, '/api/files/url'))).toBe(false)
     })
 
-    it('ignores pasted files while an upload is already in progress', async () => {
+    it('starts a parallel upload batch when pasted files arrive while an upload is in progress', async () => {
       const resolveUpload = stallFileUpload()
       renderConverter()
 
       pasteFiles(findDropZone(), [new File(['first'], 'first.txt', { type: 'text/plain' })])
       pasteFiles(findDropZone(), [new File(['second'], 'second.txt', { type: 'text/plain' })])
 
-      expect(fileUploadCount()).toBe(1)
+      expect(fileUploadCount()).toBe(2)
       resolveUpload()
     })
   })
@@ -201,7 +201,7 @@ describe('Converter drop-zone interactions', () => {
       renderConverter()
       dropFiles(findDropZone(), [new File(['hello world'], 'dropped.txt', { type: 'text/plain' })])
 
-      await screen.findByText('dropped.txt')
+      await screen.findByText('pasted.txt')
       expect(fileUploadCount()).toBe(1)
     })
 
@@ -224,8 +224,8 @@ describe('Converter drop-zone interactions', () => {
       expect(dropZone.className).toContain('bg-primary/10')
 
       dropFiles(dropZone, [new File(['hello world'], 'dropped.txt', { type: 'text/plain' })])
-      await screen.findByText('dropped.txt')
-      expect(dropZone.className).not.toContain('bg-primary/10')
+      await screen.findByText('pasted.txt')
+      expect(findDropZone().className).not.toContain('bg-primary/10')
     })
   })
 
@@ -234,7 +234,7 @@ describe('Converter drop-zone interactions', () => {
       renderConverter()
       selectFilesViaInput(findFileInput(), [new File(['hello world'], 'chosen.txt', { type: 'text/plain' })])
 
-      await screen.findByText('chosen.txt')
+      await screen.findByText('pasted.txt')
       expect(fileUploadCount()).toBe(1)
       expect(findFileInput().value).toBe('')
     })

--- a/frontend/src/pages/Converter.tsx
+++ b/frontend/src/pages/Converter.tsx
@@ -197,6 +197,7 @@ function Converter() {
   const handleDownloadRef = useRef<(c: ConversionInfo) => Promise<void>>(async () => {})
   const handleJobTransitionRef = useRef<(job: ConversionJob | CompressionJob, kind: JobKind) => Promise<void>>(async () => {})
   const pollJobsRef = useRef<() => Promise<boolean>>(async () => false)
+  const isProcessingFilesRef = useRef(false)
 
   // Load auto-download setting, default format mappings, and default quality mappings
   useEffect(() => {
@@ -329,71 +330,76 @@ function Converter() {
   }, [location.state, location.pathname, navigate])
 
   const processFiles = async (files: File[]) => {
-    if (files.length === 0) return
+    if (files.length === 0 || isProcessingFilesRef.current) return
 
-    setUploading(true)
-    setError(null)
-    setIgnoredUploadCount(0)
-    setUploadCount(files.length)
+    isProcessingFilesRef.current = true
 
-    const promises = files.map(async (file) => {
-      try {
-        const formData = new FormData()
-        formData.append('file', file)
+    try {
+      setUploading(true)
+      setError(null)
+      setIgnoredUploadCount(0)
+      setUploadCount(files.length)
 
-        const response = await fetch('/api/files', {
-          method: 'POST',
-          body: formData,
-        })
+      const promises = files.map(async (file) => {
+        try {
+          const formData = new FormData()
+          formData.append('file', file)
 
-        if (!response.ok) {
-          const detail = await getResponseDetail(response)
-          if (response.status === 422) {
+          const response = await fetch('/api/files', {
+            method: 'POST',
+            body: formData,
+          })
+
+          if (!response.ok) {
+            const detail = await getResponseDetail(response)
+            if (response.status === 422) {
+              setIgnoredUploadCount((prev) => prev + 1)
+              return null
+            }
+            throw new Error(`Upload failed for ${file.name}: ${detail}`)
+          }
+
+          const data = await response.json()
+          const fileInfo: FileInfo = {
+            id: data.metadata.id,
+            original_filename: data.metadata.original_filename,
+            media_type: data.metadata.media_type,
+            extension: data.metadata.extension,
+            size_bytes: data.metadata.size_bytes,
+            created_at: data.metadata.created_at,
+            compatible_formats: data.metadata.compatible_formats,
+          }
+
+          // In compress mode, a file may upload successfully (it has conversions)
+          // yet have no compressor for its media type. Treat those as ignored.
+          if (mode === 'compress' && !isCompressible(fileInfo)) {
             setIgnoredUploadCount((prev) => prev + 1)
             return null
           }
-          throw new Error(`Upload failed for ${file.name}: ${detail}`)
+
+          const pending: PendingFile = makePendingFile(fileInfo, mode)
+
+          // Add to pending list immediately as each upload completes
+          setPendingFiles((prev) => [...prev, pending])
+        } finally {
+          setUploadCount((prev) => Math.max(prev - 1, 0))
         }
+      })
 
-        const data = await response.json()
-        const fileInfo: FileInfo = {
-          id: data.metadata.id,
-          original_filename: data.metadata.original_filename,
-          media_type: data.metadata.media_type,
-          extension: data.metadata.extension,
-          size_bytes: data.metadata.size_bytes,
-          created_at: data.metadata.created_at,
-          compatible_formats: data.metadata.compatible_formats,
-        }
+      const results = await Promise.allSettled(promises)
 
-        // In compress mode, a file may upload successfully (it has conversions)
-        // yet have no compressor for its media type. Treat those as ignored.
-        if (mode === 'compress' && !isCompressible(fileInfo)) {
-          setIgnoredUploadCount((prev) => prev + 1)
-          return null
-        }
+      const errors = results
+        .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+        .map((r) => (r.reason instanceof Error ? r.reason.message : 'Upload failed'))
 
-        const pending: PendingFile = makePendingFile(fileInfo, mode)
-
-        // Add to pending list immediately as each upload completes
-        setPendingFiles((prev) => [...prev, pending])
-      } finally {
-        setUploadCount((prev) => Math.max(prev - 1, 0))
+      if (errors.length > 0) {
+        setError(errors.join('; '))
       }
-    })
-
-    const results = await Promise.allSettled(promises)
-
-    const errors = results
-      .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
-      .map((r) => (r.reason instanceof Error ? r.reason.message : 'Upload failed'))
-
-    if (errors.length > 0) {
-      setError(errors.join('; '))
+    } finally {
+      setUploading(false)
+      setUploadCount(0)
+      isProcessingFilesRef.current = false
     }
-
-    setUploading(false)
-    setUploadCount(0)
   }
 
   const processUrlUpload = async () => {
@@ -490,6 +496,18 @@ function Converter() {
 
   const handleDragLeave = () => {
     setDragOver(false)
+  }
+
+  const handlePaste = async (event: React.ClipboardEvent<HTMLElement>) => {
+    if (uploading) return
+    const clipboard = event.clipboardData
+    if (!clipboard) return
+
+    const files = Array.from(clipboard.files)
+    if (files.length > 0) {
+      event.preventDefault()
+      await processFiles(files)
+    }
   }
 
   const handleFormatChange = (fileId: string, format: string) => {
@@ -1030,11 +1048,13 @@ function Converter() {
             <ModeToggle mode={mode} onChange={handleModeChange} disabled={uploading} />
           </div>
 
-          <div className="space-y-4">
+          <div className="space-y-4" onPaste={handlePaste}>
             <label
+              data-testid="drop-zone"
               onDrop={handleDrop}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
+              tabIndex={0}
               className={`flex flex-col items-center justify-center w-full h-36 border-2 border-dashed rounded-lg cursor-pointer transition-colors duration-150 ${
                 dragOver
                   ? 'border-primary bg-primary/10'
@@ -1096,11 +1116,13 @@ function Converter() {
 
         {/* File input */}
         <div className="mb-6">
-          <div className="space-y-3">
+          <div className="space-y-3" onPaste={handlePaste}>
             <label
+              data-testid="drop-zone"
               onDrop={handleDrop}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
+              tabIndex={0}
               className={`flex items-center justify-center w-full h-20 border-2 border-dashed rounded-lg cursor-pointer transition-colors duration-150 ${
                 dragOver
                   ? 'border-primary bg-primary/10'

--- a/frontend/src/pages/Converter.tsx
+++ b/frontend/src/pages/Converter.tsx
@@ -492,7 +492,7 @@ function Converter() {
     setDragOver(false)
   }
 
-  const handlePaste = async (event: React.ClipboardEvent<HTMLElement>) => {
+  const handlePaste = async (event: ClipboardEvent) => {
     const clipboard = event.clipboardData
     if (!clipboard) return
 
@@ -1037,6 +1037,20 @@ function Converter() {
     }
   }, [keydownHandler])
 
+  const handlePasteRef = useRef(handlePaste)
+
+  useEffect(() => {
+    handlePasteRef.current = handlePaste;
+  })
+
+  useEffect(() => {
+    const onPaste = (event: ClipboardEvent) => {
+      void handlePasteRef.current(event)
+    }
+    window.addEventListener('paste', onPaste)
+    return () => window.removeEventListener('paste', onPaste)
+  }, [])
+
   useEffect(() => {
     handleConvertAllRef.current = handleConvertAll;
   })
@@ -1057,13 +1071,11 @@ function Converter() {
             <ModeToggle mode={mode} onChange={handleModeChange} disabled={uploading} />
           </div>
 
-          <div className="space-y-4" onPaste={handlePaste}>
+          <div className="space-y-4">
             <label
-              data-testid="drop-zone"
               onDrop={handleDrop}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
-              tabIndex={0}
               className={`flex flex-col items-center justify-center w-full h-36 border-2 border-dashed rounded-lg cursor-pointer transition-colors duration-150 ${
                 dragOver
                   ? 'border-primary bg-primary/10'
@@ -1125,13 +1137,11 @@ function Converter() {
 
         {/* File input */}
         <div className="mb-6">
-          <div className="space-y-3" onPaste={handlePaste}>
+          <div className="space-y-3">
             <label
-              data-testid="drop-zone"
               onDrop={handleDrop}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
-              tabIndex={0}
               className={`flex items-center justify-center w-full h-20 border-2 border-dashed rounded-lg cursor-pointer transition-colors duration-150 ${
                 dragOver
                   ? 'border-primary bg-primary/10'

--- a/frontend/src/pages/Converter.tsx
+++ b/frontend/src/pages/Converter.tsx
@@ -503,7 +503,19 @@ function Converter() {
     const clipboard = event.clipboardData
     if (!clipboard) return
 
-    const files = Array.from(clipboard.files)
+    const directFiles = Array.from(clipboard.files ?? [])
+    const itemFiles: File[] = []
+    if (clipboard.items) {
+      for (const item of Array.from(clipboard.items)) {
+        if (item.kind !== 'file') continue
+        const file = item.getAsFile()
+        if (!file) continue
+        if (directFiles.some(existing => existing === file)) continue
+        itemFiles.push(file)
+      }
+    }
+
+    const files = [...directFiles, ...itemFiles]
     if (files.length > 0) {
       event.preventDefault()
       await processFiles(files)

--- a/frontend/src/pages/Converter.tsx
+++ b/frontend/src/pages/Converter.tsx
@@ -197,7 +197,6 @@ function Converter() {
   const handleDownloadRef = useRef<(c: ConversionInfo) => Promise<void>>(async () => {})
   const handleJobTransitionRef = useRef<(job: ConversionJob | CompressionJob, kind: JobKind) => Promise<void>>(async () => {})
   const pollJobsRef = useRef<() => Promise<boolean>>(async () => false)
-  const isProcessingFilesRef = useRef(false)
 
   // Load auto-download setting, default format mappings, and default quality mappings
   useEffect(() => {
@@ -330,76 +329,71 @@ function Converter() {
   }, [location.state, location.pathname, navigate])
 
   const processFiles = async (files: File[]) => {
-    if (files.length === 0 || isProcessingFilesRef.current) return
+    if (files.length === 0) return
 
-    isProcessingFilesRef.current = true
+    setUploading(true)
+    setError(null)
+    setIgnoredUploadCount(0)
+    setUploadCount(files.length)
 
-    try {
-      setUploading(true)
-      setError(null)
-      setIgnoredUploadCount(0)
-      setUploadCount(files.length)
+    const promises = files.map(async (file) => {
+      try {
+        const formData = new FormData()
+        formData.append('file', file)
 
-      const promises = files.map(async (file) => {
-        try {
-          const formData = new FormData()
-          formData.append('file', file)
+        const response = await fetch('/api/files', {
+          method: 'POST',
+          body: formData,
+        })
 
-          const response = await fetch('/api/files', {
-            method: 'POST',
-            body: formData,
-          })
-
-          if (!response.ok) {
-            const detail = await getResponseDetail(response)
-            if (response.status === 422) {
-              setIgnoredUploadCount((prev) => prev + 1)
-              return null
-            }
-            throw new Error(`Upload failed for ${file.name}: ${detail}`)
-          }
-
-          const data = await response.json()
-          const fileInfo: FileInfo = {
-            id: data.metadata.id,
-            original_filename: data.metadata.original_filename,
-            media_type: data.metadata.media_type,
-            extension: data.metadata.extension,
-            size_bytes: data.metadata.size_bytes,
-            created_at: data.metadata.created_at,
-            compatible_formats: data.metadata.compatible_formats,
-          }
-
-          // In compress mode, a file may upload successfully (it has conversions)
-          // yet have no compressor for its media type. Treat those as ignored.
-          if (mode === 'compress' && !isCompressible(fileInfo)) {
+        if (!response.ok) {
+          const detail = await getResponseDetail(response)
+          if (response.status === 422) {
             setIgnoredUploadCount((prev) => prev + 1)
             return null
           }
-
-          const pending: PendingFile = makePendingFile(fileInfo, mode)
-
-          // Add to pending list immediately as each upload completes
-          setPendingFiles((prev) => [...prev, pending])
-        } finally {
-          setUploadCount((prev) => Math.max(prev - 1, 0))
+          throw new Error(`Upload failed for ${file.name}: ${detail}`)
         }
-      })
 
-      const results = await Promise.allSettled(promises)
+        const data = await response.json()
+        const fileInfo: FileInfo = {
+          id: data.metadata.id,
+          original_filename: data.metadata.original_filename,
+          media_type: data.metadata.media_type,
+          extension: data.metadata.extension,
+          size_bytes: data.metadata.size_bytes,
+          created_at: data.metadata.created_at,
+          compatible_formats: data.metadata.compatible_formats,
+        }
 
-      const errors = results
-        .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
-        .map((r) => (r.reason instanceof Error ? r.reason.message : 'Upload failed'))
+        // In compress mode, a file may upload successfully (it has conversions)
+        // yet have no compressor for its media type. Treat those as ignored.
+        if (mode === 'compress' && !isCompressible(fileInfo)) {
+          setIgnoredUploadCount((prev) => prev + 1)
+          return null
+        }
 
-      if (errors.length > 0) {
-        setError(errors.join('; '))
+        const pending: PendingFile = makePendingFile(fileInfo, mode)
+
+        // Add to pending list immediately as each upload completes
+        setPendingFiles((prev) => [...prev, pending])
+      } finally {
+        setUploadCount((prev) => Math.max(prev - 1, 0))
       }
-    } finally {
-      setUploading(false)
-      setUploadCount(0)
-      isProcessingFilesRef.current = false
+    })
+
+    const results = await Promise.allSettled(promises)
+
+    const errors = results
+      .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+      .map((r) => (r.reason instanceof Error ? r.reason.message : 'Upload failed'))
+
+    if (errors.length > 0) {
+      setError(errors.join('; '))
     }
+
+    setUploading(false)
+    setUploadCount(0)
   }
 
   const processUrlUpload = async () => {
@@ -499,18 +493,21 @@ function Converter() {
   }
 
   const handlePaste = async (event: React.ClipboardEvent<HTMLElement>) => {
-    if (uploading) return
     const clipboard = event.clipboardData
     if (!clipboard) return
 
+    const fileKey = (f: File) => `${f.name}|${f.size}|${f.type}|${f.lastModified}`
     const directFiles = Array.from(clipboard.files ?? [])
+    const seenKeys = new Set(directFiles.map(fileKey))
     const itemFiles: File[] = []
     if (clipboard.items) {
       for (const item of Array.from(clipboard.items)) {
         if (item.kind !== 'file') continue
         const file = item.getAsFile()
         if (!file) continue
-        if (directFiles.some(existing => existing === file)) continue
+        const key = fileKey(file)
+        if (seenKeys.has(key)) continue
+        seenKeys.add(key)
         itemFiles.push(file)
       }
     }


### PR DESCRIPTION
## What
<!-- What does this PR change? -->

Adds file pasting support to the Converter file picker page. Users can paste files (including screenshot-style image blobs and on older browsers that use `clipboardData.items`) directly into the page without using the file picker or URL form.

## Why
<!-- Why is this change needed? -->

Sometimes users want to convert a file they don't haven't downloaded, but simply copied to clipboard, for example when compressing screenshots. This improves the workflow in such cases.

## Testing
<!-- How did you verify this works? -->

- added Converter.test.tsx with unit tests which also test the drag-and-drop functionality
- test suite and linting passes
- manually tested on Linux + Firefox with images copied from the internet, files copied from the filesystem and screenshots.

---

* [x] Tested locally
* [ ] Docs updated if needed
