### PR TITLE
feat: add chunked file uploads and downloads for reverse-proxy compatibility (#241)

### DIFF
--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -250,8 +250,9 @@ async def upload_file_from_url(
         raise HTTPException(status_code=500, detail=f"Upload failed: {str(e)}")
 
 
-@router.get(
+@router.api_route(
     "/{file_id}",
+    methods=["GET", "HEAD"],
     summary="Download a file (either converted or original) based on file ID",
     response_class=FileResponse,
     responses={

--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -1,10 +1,11 @@
 import os
 import uuid
+import shutil
 import hashlib
 import mimetypes
 import logging
 
-from fastapi import APIRouter, File, UploadFile, HTTPException, Depends, BackgroundTasks
+from fastapi import APIRouter, File, UploadFile, HTTPException, Depends, BackgroundTasks, Request
 from fastapi.responses import FileResponse
 from zipfile import ZipFile
 from pathlib import Path
@@ -12,7 +13,12 @@ from core import get_settings, detect_media_type, sanitize_extension, sanitize_f
 from db import FileDB, ConversionDB, CompressionDB
 from registry import registry as converter_registry
 from api.deps import get_current_active_user, get_file_db, get_conversion_db, get_compression_db
-from api.schemas import FileListResponse, FileUploadResponse, FileUrlUploadResponse, FileDeleteResponse, ErrorResponse, BatchDownloadRequest, UrlUploadRequest
+from api.schemas import (
+    FileListResponse, FileUploadResponse, FileUrlUploadResponse, FileDeleteResponse,
+    ErrorResponse, BatchDownloadRequest, UrlUploadRequest,
+    ChunkedUploadInitRequest, ChunkedUploadInitResponse, ChunkedUploadChunkResponse,
+    ChunkedUploadCompleteRequest, UploadConfigResponse,
+)
 from registry import downloader_registry
 from downloaders import DownloadError, YtDlpDownloader
 from converters.ffmpeg_convert import FFmpegConverter
@@ -28,6 +34,7 @@ settings = get_settings()
 UPLOAD_DIR = settings.upload_dir
 CONVERTED_DIR = settings.output_dir
 TMP_DIR = settings.tmp_dir
+CHUNKS_DIR = settings.chunks_dir
 
 
 def resolve_downloaded_media_type(downloader: object, detected_media_type: str) -> str:
@@ -420,3 +427,220 @@ def delete_file(
         raise HTTPException(status_code=404, detail="File not found")
     delete_file_and_metadata(file_id, file_db)
     return {"message": "File deleted successfully"}
+
+
+@router.get(
+    "/config/upload",
+    summary="Get upload configuration",
+    responses={
+        200: {
+            "model": UploadConfigResponse,
+            "description": "Upload configuration including maximum chunk size",
+        }
+    },
+)
+def get_upload_config():
+    """Return upload-related configuration values."""
+    return {"max_chunk_size": settings.max_chunk_size}
+
+
+def _chunk_upload_dir(upload_id: str) -> Path:
+    """Return the per-session directory for chunked upload chunks."""
+    return CHUNKS_DIR / upload_id
+
+
+@router.post(
+    "/upload/init",
+    summary="Initialize a chunked upload session",
+    responses={
+        200: {
+            "model": ChunkedUploadInitResponse,
+            "description": "Chunked upload session initialized",
+        },
+        400: {
+            "model": ErrorResponse,
+            "description": "Invalid parameters",
+        },
+    },
+)
+def init_chunked_upload(
+    request: ChunkedUploadInitRequest,
+    current_user: dict = Depends(get_current_active_user),
+):
+    """Create a new chunked upload session and return an upload ID."""
+    if request.total_size <= 0:
+        raise HTTPException(status_code=400, detail="total_size must be positive")
+    if request.total_chunks <= 0:
+        raise HTTPException(status_code=400, detail="total_chunks must be positive")
+
+    upload_id = str(uuid.uuid4())
+    session_dir = _chunk_upload_dir(upload_id)
+    os.makedirs(session_dir, exist_ok=True)
+
+    meta_path = session_dir / "meta.json"
+    import json
+    with meta_path.open("w") as f:
+        json.dump({
+            "upload_id": upload_id,
+            "filename": request.filename,
+            "total_size": request.total_size,
+            "total_chunks": request.total_chunks,
+            "user_id": current_user["uuid"],
+        }, f)
+
+    return {"upload_id": upload_id}
+
+
+@router.post(
+    "/upload/chunk",
+    summary="Upload a single chunk",
+    responses={
+        200: {
+            "model": ChunkedUploadChunkResponse,
+            "description": "Chunk received",
+        },
+        400: {
+            "model": ErrorResponse,
+            "description": "Invalid chunk index or body",
+        },
+        404: {
+            "model": ErrorResponse,
+            "description": "Upload session not found",
+        },
+    },
+)
+async def upload_chunk(
+    request: Request,
+    upload_id: str,
+    chunk_index: int,
+    current_user: dict = Depends(get_current_active_user),
+):
+    """Receive and store a single chunk for a chunked upload session."""
+    session_dir = _chunk_upload_dir(upload_id)
+    if not session_dir.is_dir():
+        raise HTTPException(status_code=404, detail="Upload session not found")
+
+    import json
+    meta_path = session_dir / "meta.json"
+    with meta_path.open("r") as f:
+        meta = json.load(f)
+
+    if meta.get("user_id") != current_user["uuid"]:
+        raise HTTPException(status_code=404, detail="Upload session not found")
+
+    if chunk_index < 0 or chunk_index >= meta["total_chunks"]:
+        raise HTTPException(status_code=400, detail=f"chunk_index must be 0..{meta['total_chunks'] - 1}")
+
+    chunk_path = session_dir / f"{chunk_index}.part"
+    with chunk_path.open("wb") as buffer:
+        async for chunk in request.stream():
+            buffer.write(chunk)
+
+    return {"upload_id": upload_id, "chunk_index": chunk_index}
+
+
+@router.post(
+    "/upload/complete",
+    summary="Finalize a chunked upload",
+    responses={
+        200: {
+            "model": FileUploadResponse,
+            "description": "File assembled and uploaded successfully",
+        },
+        400: {
+            "model": ErrorResponse,
+            "description": "Missing chunks or invalid session",
+        },
+        404: {
+            "model": ErrorResponse,
+            "description": "Upload session not found",
+        },
+        422: {
+            "model": ErrorResponse,
+            "description": "File has no supported conversions",
+        },
+        500: {
+            "model": ErrorResponse,
+            "description": "Upload finalization failed",
+        },
+    },
+)
+def complete_chunked_upload(
+    request: ChunkedUploadCompleteRequest,
+    file_db: FileDB = Depends(get_file_db),
+    current_user: dict = Depends(get_current_active_user),
+):
+    """Assemble all chunks into the final file, validate, and store metadata."""
+    import json
+
+    session_dir = _chunk_upload_dir(request.upload_id)
+    if not session_dir.is_dir():
+        raise HTTPException(status_code=404, detail="Upload session not found")
+
+    meta_path = session_dir / "meta.json"
+    try:
+        with meta_path.open("r") as f:
+            meta = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        raise HTTPException(status_code=400, detail="Invalid session metadata")
+
+    if meta.get("user_id") != current_user["uuid"]:
+        raise HTTPException(status_code=404, detail="Upload session not found")
+
+    total_chunks = meta["total_chunks"]
+    original_filename = meta["filename"]
+
+    for i in range(total_chunks):
+        if not (session_dir / f"{i}.part").exists():
+            raise HTTPException(status_code=400, detail=f"Missing chunk {i}")
+
+    try:
+        uuid_str = str(uuid.uuid4())
+        file_extension = get_file_extension(original_filename)
+        unique_filename = f"{uuid_str}"
+        if file_extension:
+            unique_filename += f".{file_extension}"
+        os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+        file_path = Path(UPLOAD_DIR) / unique_filename
+        hasher = hashlib.sha256()
+        size_bytes = 0
+
+        with file_path.open("wb") as out:
+            for i in range(total_chunks):
+                chunk_path = session_dir / f"{i}.part"
+                with chunk_path.open("rb") as cf:
+                    while True:
+                        data = cf.read(1024 * 1024)
+                        if not data:
+                            break
+                        out.write(data)
+                        hasher.update(data)
+                        size_bytes += len(data)
+
+        shutil.rmtree(session_dir, ignore_errors=True)
+
+        media_type = detect_media_type(file_path)
+        compatible_formats = converter_registry.get_compatible_formats_and_qualities(media_type)
+        if not compatible_formats:
+            file_path.unlink(missing_ok=True)
+            raise HTTPException(status_code=422, detail=UNSUPPORTED_UPLOAD_DETAIL)
+
+        metadata = {
+            "id": uuid_str,
+            "storage_path": str(file_path),
+            "original_filename": original_filename,
+            "media_type": media_type,
+            "extension": file_extension,
+            "size_bytes": size_bytes,
+            "sha256_checksum": hasher.hexdigest(),
+            "user_id": current_user["uuid"],
+        }
+        file_db.insert_file_metadata(metadata)
+        metadata["compatible_formats"] = compatible_formats
+        return {"message": "File uploaded successfully", "metadata": metadata}
+    except HTTPException:
+        raise
+    except Exception as e:
+        shutil.rmtree(session_dir, ignore_errors=True)
+        raise HTTPException(status_code=500, detail=f"Upload finalization failed: {str(e)}")

--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -533,8 +533,14 @@ async def upload_chunk(
         raise HTTPException(status_code=400, detail=f"chunk_index must be 0..{meta['total_chunks'] - 1}")
 
     chunk_path = session_dir / f"{chunk_index}.part"
+    max_bytes = settings.max_chunk_size + 1024
+    written = 0
     with chunk_path.open("wb") as buffer:
         async for chunk in request.stream():
+            written += len(chunk)
+            if written > max_bytes:
+                chunk_path.unlink(missing_ok=True)
+                raise HTTPException(status_code=413, detail="Chunk exceeds max_chunk_size")
             buffer.write(chunk)
 
     return {"upload_id": upload_id, "chunk_index": chunk_index}
@@ -595,6 +601,7 @@ def complete_chunked_upload(
         if not (session_dir / f"{i}.part").exists():
             raise HTTPException(status_code=400, detail=f"Missing chunk {i}")
 
+    file_path = None
     try:
         uuid_str = str(uuid.uuid4())
         file_extension = get_file_extension(original_filename)
@@ -643,5 +650,7 @@ def complete_chunked_upload(
     except HTTPException:
         raise
     except Exception as e:
+        if file_path is not None:
+            file_path.unlink(missing_ok=True)
         shutil.rmtree(session_dir, ignore_errors=True)
         raise HTTPException(status_code=500, detail=f"Upload finalization failed: {str(e)}")

--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -445,6 +445,14 @@ def get_upload_config():
     return {"max_chunk_size": settings.max_chunk_size}
 
 
+def _validate_upload_id(upload_id: str) -> None:
+    """Validate that upload_id is a valid UUID to prevent directory traversal."""
+    try:
+        uuid.UUID(upload_id)
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(status_code=400, detail="Invalid upload_id format")
+
+
 def _chunk_upload_dir(upload_id: str) -> Path:
     """Return the per-session directory for chunked upload chunks."""
     return CHUNKS_DIR / upload_id
@@ -517,6 +525,7 @@ async def upload_chunk(
     current_user: dict = Depends(get_current_active_user),
 ):
     """Receive and store a single chunk for a chunked upload session."""
+    _validate_upload_id(upload_id)
     session_dir = _chunk_upload_dir(upload_id)
     if not session_dir.is_dir():
         raise HTTPException(status_code=404, detail="Upload session not found")
@@ -582,6 +591,7 @@ def complete_chunked_upload(
     """Assemble all chunks into the final file, validate, and store metadata."""
     import json
 
+    _validate_upload_id(request.upload_id)
     session_dir = _chunk_upload_dir(request.upload_id)
     if not session_dir.is_dir():
         raise HTTPException(status_code=404, detail="Upload session not found")

--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -640,6 +640,13 @@ def complete_chunked_upload(
                         hasher.update(data)
                         size_bytes += len(data)
 
+        if size_bytes != meta["total_size"]:
+            file_path.unlink(missing_ok=True)
+            raise HTTPException(
+                status_code=400,
+                detail=f"Size mismatch: expected {meta['total_size']} bytes but received {size_bytes} bytes",
+            )
+
         shutil.rmtree(session_dir, ignore_errors=True)
 
         media_type = detect_media_type(file_path)

--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -440,7 +440,9 @@ def delete_file(
         }
     },
 )
-def get_upload_config():
+def get_upload_config(
+    current_user: dict = Depends(get_current_active_user),
+):
     """Return upload-related configuration values."""
     return {"max_chunk_size": settings.max_chunk_size}
 

--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -533,15 +533,17 @@ async def upload_chunk(
         raise HTTPException(status_code=400, detail=f"chunk_index must be 0..{meta['total_chunks'] - 1}")
 
     chunk_path = session_dir / f"{chunk_index}.part"
-    max_bytes = settings.max_chunk_size + 1024
     written = 0
-    with chunk_path.open("wb") as buffer:
-        async for chunk in request.stream():
-            written += len(chunk)
-            if written > max_bytes:
-                chunk_path.unlink(missing_ok=True)
-                raise HTTPException(status_code=413, detail="Chunk exceeds max_chunk_size")
-            buffer.write(chunk)
+    try:
+        with chunk_path.open("wb") as buffer:
+            async for chunk in request.stream():
+                written += len(chunk)
+                if settings.max_chunk_size > 0 and written > settings.max_chunk_size + 1024:
+                    raise HTTPException(status_code=413, detail="Chunk exceeds max_chunk_size")
+                buffer.write(chunk)
+    except Exception:
+        chunk_path.unlink(missing_ok=True)
+        raise
 
     return {"upload_id": upload_id, "chunk_index": chunk_index}
 

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -141,6 +141,29 @@ class BatchDownloadRequest(BaseModel):
     file_ids: list[str] = Field(..., description="List of converted file IDs to download", json_schema_extra={"example": ["123e4567-e89b-12d3-a456-426614174000", "987fcdeb-51a2-43f1-b789-123456789abc"]})
 
 
+class ChunkedUploadInitRequest(BaseModel):
+    filename: str = Field(..., description="Original filename including extension", json_schema_extra={"example": "large_video.mp4"})
+    total_size: int = Field(..., description="Total file size in bytes", json_schema_extra={"example": 104857600})
+    total_chunks: int = Field(..., description="Number of chunks the file is split into", json_schema_extra={"example": 3})
+
+
+class ChunkedUploadInitResponse(BaseModel):
+    upload_id: str = Field(..., description="UUID identifying this chunked upload session", json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"})
+
+
+class ChunkedUploadChunkResponse(BaseModel):
+    upload_id: str = Field(..., description="Upload session UUID")
+    chunk_index: int = Field(..., description="Index of the chunk that was received")
+
+
+class ChunkedUploadCompleteRequest(BaseModel):
+    upload_id: str = Field(..., description="Upload session UUID to finalize", json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"})
+
+
+class UploadConfigResponse(BaseModel):
+    max_chunk_size: int = Field(..., description="Maximum bytes per request; files larger than this should be uploaded in chunks")
+
+
 ThemeValue = Literal["rubedo", "citrinitas", "viriditas", "nigredo", "albedo", "aurora", "caelum", "argentum"]
 UserRoleValue = Literal["admin", "member", "guest"]
 

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -161,7 +161,7 @@ class ChunkedUploadCompleteRequest(BaseModel):
 
 
 class UploadConfigResponse(BaseModel):
-    max_chunk_size: int = Field(..., description="Maximum bytes per request; files larger than this should be uploaded in chunks")
+    max_chunk_size: int = Field(..., description="Maximum bytes per request; files larger than this should be uploaded in chunks. 0 = unlimited")
 
 
 ThemeValue = Literal["rubedo", "citrinitas", "viriditas", "nigredo", "albedo", "aurora", "caelum", "argentum"]

--- a/backend/background/cleanup.py
+++ b/backend/background/cleanup.py
@@ -2,9 +2,12 @@ import logging
 import calendar
 import threading
 import time
+import shutil
+import os
 
+from pathlib import Path
 from db import FileDB, ConversionDB, ConversionRelationsDB, SettingsDB, DefaultFormatsDB, UserDB, ApiKeyDB
-from core import delete_file_and_metadata
+from core import delete_file_and_metadata, get_settings
 
 
 logger = logging.getLogger(__name__)
@@ -65,6 +68,25 @@ def guest_cleanup_logic() -> None:
         logger.info("Deleted expired guest user %s", guest_uuid)
 
 
+def chunk_cleanup_logic() -> None:
+    """Remove stale incomplete chunked upload sessions older than 24 hours."""
+    settings = get_settings()
+    chunks_dir = settings.chunks_dir
+    if not chunks_dir or not chunks_dir.is_dir():
+        return
+
+    cutoff = time.time() - 86400
+    for entry in chunks_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        try:
+            if entry.stat().st_mtime < cutoff:
+                shutil.rmtree(entry, ignore_errors=True)
+                logger.info("Removed stale chunked upload session %s", entry.name)
+        except OSError:
+            logger.exception("Failed to clean up chunk session %s", entry.name)
+
+
 def file_cleanup_task() -> None:
     """Periodically run cleanup logic for uploaded and converted files.
 
@@ -77,6 +99,7 @@ def file_cleanup_task() -> None:
             file_cleanup_logic(FileDB())
             file_cleanup_logic(ConversionDB(), ConversionRelationsDB())
             guest_cleanup_logic()
+            chunk_cleanup_logic()
         except Exception:
             logger.exception("Cleanup error")
         time.sleep(60) # Sleep for 1 minute

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     upload_dir: Path | None = None
     output_dir: Path | None = None
     tmp_dir: Path | None = None
+    chunks_dir: Path | None = None
 
     # ===== SQLite =====
     file_table_name: str = "FILES_METADATA"
@@ -88,6 +89,12 @@ class Settings(BaseSettings):
     oidc_username_claim: str = "preferred_username"
     oidc_auto_create_users: bool = True
     oidc_auto_launch: bool = False  # If True, automatically redirect to OIDC login when accessing /auth
+
+    # ===== Chunked Transfers =====
+    # Maximum size in bytes of a single HTTP request for uploads/downloads.
+    # Files larger than this are split into chunks to stay under reverse-proxy
+    # limits (e.g. Cloudflare's 100 MB cap).  Default: 50 MB.
+    max_chunk_size: int = 52428800
 
     # ===== Guest Access =====
     allow_unauthenticated: bool = False
@@ -183,6 +190,7 @@ class Settings(BaseSettings):
         self.upload_dir = self.data_dir / "uploads"
         self.output_dir = self.data_dir / "outputs"
         self.tmp_dir = self.data_dir / "tmp"
+        self.chunks_dir = self.data_dir / "chunks"
         self.pdf_css_dir = self.data_dir / "pdf"
         self.pdf_custom_css_path = self.pdf_css_dir / "custom.css"
 
@@ -198,6 +206,7 @@ class Settings(BaseSettings):
             self.upload_dir,
             self.output_dir,
             self.tmp_dir,
+            self.chunks_dir,
             self.pdf_css_dir,
         ]:
             path.mkdir(parents=True, exist_ok=True)

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -92,9 +92,9 @@ class Settings(BaseSettings):
 
     # ===== Chunked Transfers =====
     # Maximum size in bytes of a single HTTP request for uploads/downloads.
-    # Files larger than this are split into chunks to stay under reverse-proxy
-    # limits (e.g. Cloudflare's 100 MB cap).  Default: 50 MB.
-    max_chunk_size: int = 52428800
+    # Files larger than this are split into chunks. Helpful for avoiding request body size limits
+    # imposed by reverse proxies. 0 = unlimited (no chunking).
+    max_chunk_size: int = 0
 
     # ===== Guest Access =====
     allow_unauthenticated: bool = False

--- a/backend/tests/api/test_chunked_upload.py
+++ b/backend/tests/api/test_chunked_upload.py
@@ -6,8 +6,11 @@ from unittest.mock import MagicMock
 from fastapi import HTTPException
 
 from api.routes import files as files_module
-from api.routes.files import complete_chunked_upload
-from api.schemas import ChunkedUploadCompleteRequest
+from api.routes.files import (
+    complete_chunked_upload,
+    init_chunked_upload,
+)
+from api.schemas import ChunkedUploadCompleteRequest, ChunkedUploadInitRequest
 
 
 def _setup_session(tmp_path, monkeypatch, total_size, total_chunks, chunk_data):
@@ -44,7 +47,7 @@ def _setup_session(tmp_path, monkeypatch, total_size, total_chunks, chunk_data):
     return upload_id, upload_dir
 
 
-def test_complete_rejects_size_mismatch(tmp_path, monkeypatch):
+def test_rejects_size_mismatch(tmp_path, monkeypatch):
     chunk_data = [b"a" * 30, b"b" * 20]
     upload_id, upload_dir = _setup_session(
         tmp_path, monkeypatch, total_size=100, total_chunks=2, chunk_data=chunk_data
@@ -67,7 +70,7 @@ def test_complete_rejects_size_mismatch(tmp_path, monkeypatch):
     assert not any(upload_dir.iterdir()), "Partial file should have been cleaned up"
 
 
-def test_complete_succeeds_when_size_matches(tmp_path, monkeypatch):
+def test_succeeds_when_size_matches(tmp_path, monkeypatch):
     chunk_data = [b"a" * 30, b"b" * 20]
     upload_id, upload_dir = _setup_session(
         tmp_path, monkeypatch, total_size=50, total_chunks=2, chunk_data=chunk_data
@@ -89,3 +92,104 @@ def test_complete_succeeds_when_size_matches(tmp_path, monkeypatch):
     assembled = Path(stored["storage_path"])
     assert assembled.exists()
     assert assembled.read_bytes() == b"a" * 30 + b"b" * 20
+
+
+def test_rejects_invalid_upload_id(tmp_path, monkeypatch):
+    chunks_dir = tmp_path / "chunks"
+    chunks_dir.mkdir()
+    monkeypatch.setattr(files_module, "CHUNKS_DIR", chunks_dir)
+
+    file_db = MagicMock()
+    user = {"uuid": "user-1"}
+    request = ChunkedUploadCompleteRequest(upload_id="../etc/passwd")
+
+    with pytest.raises(HTTPException) as exc_info:
+        complete_chunked_upload(request, file_db=file_db, current_user=user)
+
+    assert exc_info.value.status_code == 400
+    file_db.insert_file_metadata.assert_not_called()
+
+
+def test_rejects_missing_chunk(tmp_path, monkeypatch):
+    chunk_data = [b"a" * 30]
+    upload_id, _ = _setup_session(
+        tmp_path, monkeypatch, total_size=50, total_chunks=2, chunk_data=chunk_data
+    )
+
+    file_db = MagicMock()
+    user = {"uuid": "user-1"}
+    request = ChunkedUploadCompleteRequest(upload_id=upload_id)
+
+    with pytest.raises(HTTPException) as exc_info:
+        complete_chunked_upload(request, file_db=file_db, current_user=user)
+
+    assert exc_info.value.status_code == 400
+    assert "Missing chunk 1" in exc_info.value.detail
+    file_db.insert_file_metadata.assert_not_called()
+
+
+def test_rejects_user_mismatch(tmp_path, monkeypatch):
+    chunk_data = [b"a" * 30, b"b" * 20]
+    upload_id, _ = _setup_session(
+        tmp_path, monkeypatch, total_size=50, total_chunks=2, chunk_data=chunk_data
+    )
+
+    file_db = MagicMock()
+    user = {"uuid": "different-user"}
+    request = ChunkedUploadCompleteRequest(upload_id=upload_id)
+
+    with pytest.raises(HTTPException) as exc_info:
+        complete_chunked_upload(request, file_db=file_db, current_user=user)
+
+    assert exc_info.value.status_code == 404
+    file_db.insert_file_metadata.assert_not_called()
+
+
+def test_rejects_unsupported_format(tmp_path, monkeypatch):
+    chunk_data = [b"a" * 30, b"b" * 20]
+    upload_id, upload_dir = _setup_session(
+        tmp_path, monkeypatch, total_size=50, total_chunks=2, chunk_data=chunk_data
+    )
+
+    monkeypatch.setattr(
+        files_module.converter_registry,
+        "get_compatible_formats_and_qualities",
+        lambda _: [],
+    )
+
+    file_db = MagicMock()
+    user = {"uuid": "user-1"}
+    request = ChunkedUploadCompleteRequest(upload_id=upload_id)
+
+    with pytest.raises(HTTPException) as exc_info:
+        complete_chunked_upload(request, file_db=file_db, current_user=user)
+
+    assert exc_info.value.status_code == 422
+    file_db.insert_file_metadata.assert_not_called()
+
+    assert not any(upload_dir.iterdir()), "Assembled file should have been cleaned up"
+
+
+def test_init_creates_session(tmp_path, monkeypatch):
+    chunks_dir = tmp_path / "chunks"
+    chunks_dir.mkdir()
+    monkeypatch.setattr(files_module, "CHUNKS_DIR", chunks_dir)
+
+    user = {"uuid": "user-1"}
+    request = ChunkedUploadInitRequest(
+        filename="big.mp4", total_size=1000, total_chunks=3
+    )
+
+    result = init_chunked_upload(request, current_user=user)
+
+    upload_id = result["upload_id"]
+    uuid.UUID(upload_id)
+
+    session_dir = chunks_dir / upload_id
+    assert session_dir.is_dir()
+
+    meta = json.loads((session_dir / "meta.json").read_text())
+    assert meta["filename"] == "big.mp4"
+    assert meta["total_size"] == 1000
+    assert meta["total_chunks"] == 3
+    assert meta["user_id"] == "user-1"

--- a/backend/tests/api/test_chunked_upload.py
+++ b/backend/tests/api/test_chunked_upload.py
@@ -1,40 +1,91 @@
+import json
+import uuid
 import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
 from fastapi import HTTPException
-from api.routes.files import _validate_upload_id
+
+from api.routes import files as files_module
+from api.routes.files import complete_chunked_upload
+from api.schemas import ChunkedUploadCompleteRequest
 
 
-def test_validate_upload_id_accepts_valid_uuid():
-    _validate_upload_id("12345678-1234-5678-1234-567812345678")
-    _validate_upload_id("00000000-0000-0000-0000-000000000000")
-    _validate_upload_id("ffffffff-ffff-ffff-ffff-ffffffffffff")
+def _setup_session(tmp_path, monkeypatch, total_size, total_chunks, chunk_data):
+    chunks_dir = tmp_path / "chunks"
+    upload_dir = tmp_path / "uploads"
+    chunks_dir.mkdir()
+    upload_dir.mkdir()
+
+    monkeypatch.setattr(files_module, "CHUNKS_DIR", chunks_dir)
+    monkeypatch.setattr(files_module, "UPLOAD_DIR", upload_dir)
+    monkeypatch.setattr(files_module, "detect_media_type", lambda _: "mp4")
+    monkeypatch.setattr(
+        files_module.converter_registry,
+        "get_compatible_formats_and_qualities",
+        lambda _: [("mp3", "128k")],
+    )
+
+    upload_id = str(uuid.uuid4())
+    session_dir = chunks_dir / upload_id
+    session_dir.mkdir()
+
+    meta = {
+        "upload_id": upload_id,
+        "filename": "test.mp4",
+        "total_size": total_size,
+        "total_chunks": total_chunks,
+        "user_id": "user-1",
+    }
+    (session_dir / "meta.json").write_text(json.dumps(meta))
+
+    for i, data in enumerate(chunk_data):
+        (session_dir / f"{i}.part").write_bytes(data)
+
+    return upload_id, upload_dir
 
 
-def test_validate_upload_id_rejects_directory_traversal():
+def test_complete_rejects_size_mismatch(tmp_path, monkeypatch):
+    chunk_data = [b"a" * 30, b"b" * 20]
+    upload_id, upload_dir = _setup_session(
+        tmp_path, monkeypatch, total_size=100, total_chunks=2, chunk_data=chunk_data
+    )
+
+    file_db = MagicMock()
+    user = {"uuid": "user-1"}
+    request = ChunkedUploadCompleteRequest(upload_id=upload_id)
+
     with pytest.raises(HTTPException) as exc_info:
-        _validate_upload_id("../../etc")
+        complete_chunked_upload(request, file_db=file_db, current_user=user)
+
     assert exc_info.value.status_code == 400
-    assert "Invalid upload_id format" in exc_info.value.detail
+    assert "Size mismatch" in exc_info.value.detail
+    assert "100" in exc_info.value.detail
+    assert "50" in exc_info.value.detail
+
+    file_db.insert_file_metadata.assert_not_called()
+
+    assert not any(upload_dir.iterdir()), "Partial file should have been cleaned up"
 
 
-def test_validate_upload_id_rejects_path_separators():
-    with pytest.raises(HTTPException) as exc_info:
-        _validate_upload_id("foo/bar")
-    assert exc_info.value.status_code == 400
+def test_complete_succeeds_when_size_matches(tmp_path, monkeypatch):
+    chunk_data = [b"a" * 30, b"b" * 20]
+    upload_id, upload_dir = _setup_session(
+        tmp_path, monkeypatch, total_size=50, total_chunks=2, chunk_data=chunk_data
+    )
 
+    file_db = MagicMock()
+    user = {"uuid": "user-1"}
+    request = ChunkedUploadCompleteRequest(upload_id=upload_id)
 
-def test_validate_upload_id_rejects_empty_string():
-    with pytest.raises(HTTPException) as exc_info:
-        _validate_upload_id("")
-    assert exc_info.value.status_code == 400
+    result = complete_chunked_upload(request, file_db=file_db, current_user=user)
 
+    assert result["message"] == "File uploaded successfully"
+    file_db.insert_file_metadata.assert_called_once()
+    stored = file_db.insert_file_metadata.call_args[0][0]
+    assert stored["size_bytes"] == 50
+    assert stored["original_filename"] == "test.mp4"
+    assert stored["user_id"] == "user-1"
 
-def test_validate_upload_id_rejects_none():
-    with pytest.raises(HTTPException) as exc_info:
-        _validate_upload_id(None)
-    assert exc_info.value.status_code == 400
-
-
-def test_validate_upload_id_rejects_arbitrary_strings():
-    with pytest.raises(HTTPException) as exc_info:
-        _validate_upload_id("not-a-uuid")
-    assert exc_info.value.status_code == 400
+    assembled = Path(stored["storage_path"])
+    assert assembled.exists()
+    assert assembled.read_bytes() == b"a" * 30 + b"b" * 20

--- a/backend/tests/api/test_chunked_upload.py
+++ b/backend/tests/api/test_chunked_upload.py
@@ -1,0 +1,40 @@
+import pytest
+from fastapi import HTTPException
+from api.routes.files import _validate_upload_id
+
+
+def test_validate_upload_id_accepts_valid_uuid():
+    _validate_upload_id("12345678-1234-5678-1234-567812345678")
+    _validate_upload_id("00000000-0000-0000-0000-000000000000")
+    _validate_upload_id("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+
+def test_validate_upload_id_rejects_directory_traversal():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_upload_id("../../etc")
+    assert exc_info.value.status_code == 400
+    assert "Invalid upload_id format" in exc_info.value.detail
+
+
+def test_validate_upload_id_rejects_path_separators():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_upload_id("foo/bar")
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_upload_id_rejects_empty_string():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_upload_id("")
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_upload_id_rejects_none():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_upload_id(None)
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_upload_id_rejects_arbitrary_strings():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_upload_id("not-a-uuid")
+    assert exc_info.value.status_code == 400

--- a/backend/tests/background/test_cleanup.py
+++ b/backend/tests/background/test_cleanup.py
@@ -1,4 +1,6 @@
+import os
 import time
+import uuid
 import threading
 import pytest
 from unittest.mock import MagicMock, patch
@@ -6,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from background.cleanup import (
     file_cleanup_logic,
     guest_cleanup_logic,
+    chunk_cleanup_logic,
     file_cleanup_task,
     get_upload_cleanup_thread,
 )
@@ -203,3 +206,38 @@ def test_returns_daemon_thread():
     assert isinstance(t, threading.Thread)
     assert t.daemon is True
     assert t.is_alive() is False
+
+
+# ── chunk_cleanup_logic ──────────────────────────────────────────────
+
+class TestChunkCleanupLogic:
+
+    def test_removes_stale_sessions(self, tmp_path, monkeypatch):
+        chunks_dir = tmp_path / "chunks"
+        chunks_dir.mkdir()
+        stale = chunks_dir / str(uuid.uuid4())
+        stale.mkdir()
+        (stale / "0.part").write_bytes(b"data")
+
+        old_time = time.time() - 90000
+        os.utime(stale, (old_time, old_time))
+
+        monkeypatch.setattr("background.cleanup.get_settings", lambda: MagicMock(chunks_dir=chunks_dir))
+
+        chunk_cleanup_logic()
+
+        assert not stale.exists()
+
+    def test_keeps_fresh_sessions(self, tmp_path, monkeypatch):
+        chunks_dir = tmp_path / "chunks"
+        chunks_dir.mkdir()
+        fresh = chunks_dir / str(uuid.uuid4())
+        fresh.mkdir()
+        (fresh / "0.part").write_bytes(b"data")
+
+        monkeypatch.setattr("background.cleanup.get_settings", lambda: MagicMock(chunks_dir=chunks_dir))
+
+        chunk_cleanup_logic()
+
+        assert fresh.exists()
+        assert (fresh / "0.part").read_bytes() == b"data"

--- a/frontend/src/pages/Converter.tsx
+++ b/frontend/src/pages/Converter.tsx
@@ -5,8 +5,8 @@ import { FaListCheck } from 'react-icons/fa6'
 import { useTranslation } from 'react-i18next'
 import FileTable, { FileInfo, ConversionInfo } from '../components/FileTable'
 import { isPreviewable } from '../components/previewUtils'
-import { authFetch as fetch, apiJson } from '../utils/api'
-import { downloadBlob } from '../utils/download'
+import { authFetch as fetch, apiJson, chunkedUpload, getUploadConfig, ApiError } from '../utils/api'
+import { downloadBlob, downloadFile } from '../utils/download'
 import { stripExtension } from '../utils/filename'
 import {
   createJob,
@@ -187,6 +187,7 @@ function Converter() {
   const [compressibleFormats, setCompressibleFormats] = useState<Set<string>>(new Set())
   const [previewFile, setPreviewFile] = useState<{ id: string; filename: string; mediaType: string } | null>(null)
   const [activeJobCount, setActiveJobCount] = useState(0)
+  const [chunkSize, setChunkSize] = useState(0)
 
   // Keep mutable references so polling can read latest values without
   // forcing the interval effect to restart on every render.
@@ -251,6 +252,9 @@ function Converter() {
         for (const d of data.defaults) map[d.media_format] = d.compression_level
         setDefaultCompressionLevels(map)
       })
+      .catch(() => {})
+    getUploadConfig()
+      .then(data => setChunkSize(data.max_chunk_size))
       .catch(() => {})
   }, [])
 
@@ -338,24 +342,38 @@ function Converter() {
 
     const promises = files.map(async (file) => {
       try {
-        const formData = new FormData()
-        formData.append('file', file)
+        let data: { metadata: FileInfo }
 
-        const response = await fetch('/api/files', {
-          method: 'POST',
-          body: formData,
-        })
-
-        if (!response.ok) {
-          const detail = await getResponseDetail(response)
-          if (response.status === 422) {
-            setIgnoredUploadCount((prev) => prev + 1)
-            return null
+        if (chunkSize > 0 && file.size > chunkSize) {
+          try {
+            data = await chunkedUpload(file, chunkSize) as { metadata: FileInfo }
+          } catch (err) {
+            if (err instanceof ApiError && err.status === 422) {
+              setIgnoredUploadCount((prev) => prev + 1)
+              return null
+            }
+            throw err
           }
-          throw new Error(`Upload failed for ${file.name}: ${detail}`)
-        }
+        } else {
+          const formData = new FormData()
+          formData.append('file', file)
 
-        const data = await response.json()
+          const response = await fetch('/api/files', {
+            method: 'POST',
+            body: formData,
+          })
+
+          if (!response.ok) {
+            const detail = await getResponseDetail(response)
+            if (response.status === 422) {
+              setIgnoredUploadCount((prev) => prev + 1)
+              return null
+            }
+            throw new Error(`Upload failed for ${file.name}: ${detail}`)
+          }
+
+          data = await response.json()
+        }
         const fileInfo: FileInfo = {
           id: data.metadata.id,
           original_filename: data.metadata.original_filename,
@@ -680,14 +698,10 @@ function Converter() {
   const handleDownload = async (conversion: ConversionInfo) => {
     setDownloadingId(conversion.id)
     try {
-      const response = await fetch(`/api/files/${conversion.id}`)
-      if (!response.ok) throw new Error('Download failed')
-
       let filename = stripExtension(conversion.original_filename || 'download')
       filename += conversion.extension || ''
-      
-      const blob = await response.blob();
-      downloadBlob(blob, filename);
+
+      await downloadFile(`/api/files/${conversion.id}`, filename, chunkSize)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Download failed')
     } finally {

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -2,9 +2,9 @@ import { lazy, Suspense, useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import FileTable, { FileInfo, ConversionInfo, FileTableRow, JobStatus } from '../components/FileTable'
 import { isPreviewable } from '../components/previewUtils'
-import { authFetch as fetch } from '../utils/api'
+import { authFetch as fetch, getUploadConfig } from '../utils/api'
 import { parseUtcTimestamp } from '../utils/datetime'
-import { downloadBlob } from '../utils/download'
+import { downloadBlob, downloadFile } from '../utils/download'
 import { stripExtension } from '../utils/filename'
 import { cancelJob, deleteJob, listJobs, retryJob, isTerminalJobStatus, type ConversionJob,
   cancelCompressionJob, deleteCompressionJob, listCompressionJobs, retryCompressionJob, type CompressionJob } from '../utils/jobs'
@@ -62,6 +62,7 @@ function History() {
   const [deletingSelected, setDeletingSelected] = useState(false)
   const [downloadingSelected, setDownloadingSelected] = useState(false)
   const [previewConversion, setPreviewConversion] = useState<ConversionRecord | null>(null)
+  const [chunkSize, setChunkSize] = useState(0)
   const { t } = useTranslation()
   const isMountedRef = useRef(true)
 
@@ -102,6 +103,12 @@ function History() {
     }
   }, [refresh])
 
+  useEffect(() => {
+    getUploadConfig()
+      .then(data => setChunkSize(data.max_chunk_size))
+      .catch(() => {})
+  }, [])
+
   // Poll while at least one job is non-terminal.
   const hasActiveJobs = jobs.some(j => !isTerminalJobStatus(j.status))
     || compressionJobs.some(j => !isTerminalJobStatus(j.status))
@@ -114,14 +121,10 @@ function History() {
   const handleDownload = async (conversion: ConversionRecord) => {
     setDownloadingId(conversion.id)
     try {
-      const response = await fetch(`/api/files/${conversion.id}`)
-      if (!response.ok) throw new Error('Download failed')
-
       let filename = stripExtension(conversion.original_filename || 'download')
       filename += conversion.extension || ''
 
-      const blob = await response.blob();
-      downloadBlob(blob, filename);
+      await downloadFile(`/api/files/${conversion.id}`, filename, chunkSize)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Download failed')
     } finally {
@@ -184,12 +187,10 @@ function History() {
   const handleDownloadCompression = async (compression: CompressionRecord) => {
     setDownloadingId(compression.id)
     try {
-      const response = await fetch(`/api/files/${compression.id}`)
-      if (!response.ok) throw new Error('Download failed')
       let filename = stripExtension(compression.original_filename || 'download')
       filename += compression.extension || ''
-      const blob = await response.blob()
-      downloadBlob(blob, filename)
+
+      await downloadFile(`/api/files/${compression.id}`, filename, chunkSize)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Download failed')
     } finally {

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -50,6 +50,20 @@ Object.defineProperty(globalThis, 'sessionStorage', {
   value: sessionStorageMock,
 })
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})
+
 import '../i18n'
 
 afterEach(() => {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -147,3 +147,61 @@ export const publicFetch = (input: RequestInfo | URL, init: RequestInit = {}) =>
 export const apiJson = <T,>(input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) => api.json<T>(input, init, options)
 export const apiBlob = (input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) => api.blob(input, init, options)
 export const apiText = (input: RequestInfo | URL, init: RequestInit = {}, options: FetchOptions = {}) => api.text(input, init, options)
+
+export async function getUploadConfig(): Promise<{ max_chunk_size: number }> {
+  return apiJson<{ max_chunk_size: number }>('/api/files/config/upload')
+}
+
+export interface ChunkedUploadProgress {
+  bytesUploaded: number
+  totalBytes: number
+  chunksUploaded: number
+  totalChunks: number
+}
+
+export async function chunkedUpload(
+  file: File,
+  chunkSize: number,
+  onProgress?: (progress: ChunkedUploadProgress) => void,
+): Promise<unknown> {
+  const totalChunks = Math.ceil(file.size / chunkSize)
+
+  const initResp = await api.json<{ upload_id: string }>('/api/files/upload/init', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      filename: file.name,
+      total_size: file.size,
+      total_chunks: totalChunks,
+    }),
+  })
+  const uploadId = initResp.upload_id
+
+  let bytesUploaded = 0
+
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * chunkSize
+    const end = Math.min(start + chunkSize, file.size)
+    const chunk = file.slice(start, end)
+
+    const params = new URLSearchParams({ upload_id: uploadId, chunk_index: String(i) })
+    const resp = await api.fetch(`/api/files/upload/chunk?${params}`, {
+      method: 'POST',
+      body: chunk,
+      headers: { 'Content-Type': 'application/octet-stream' },
+    })
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => resp.statusText)
+      throw new ApiError(resp.status, text || `Chunk ${i} upload failed`)
+    }
+
+    bytesUploaded += end - start
+    onProgress?.({ bytesUploaded, totalBytes: file.size, chunksUploaded: i + 1, totalChunks })
+  }
+
+  return api.json('/api/files/upload/complete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ upload_id: uploadId }),
+  })
+}

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -52,19 +52,15 @@ export function downloadBlob(blob: Blob, filename: string): void {
 }
 
 /**
- * Download a file using HTTP Range requests, splitting the transfer into
- * chunks to stay under reverse-proxy size limits.
- *
+ * Download a file using HTTP Range requests, splitting the transfer into chunks
  * @param url - The API URL to download from (e.g. `/api/files/{id}`)
  * @param filename - The filename to save as
  * @param chunkSize - Maximum bytes per range request
- * @param onProgress - Optional callback with (bytesDownloaded, totalBytes)
  */
 export async function downloadChunked(
   url: string,
   filename: string,
   chunkSize: number,
-  onProgress?: (bytesDownloaded: number, totalBytes: number) => void,
 ): Promise<void> {
   const headResp = await fetch(url, { method: 'HEAD' })
   if (!headResp.ok) throw new Error(`Download failed: ${headResp.statusText}`)
@@ -75,10 +71,7 @@ export async function downloadChunked(
 
   if (totalBytes === 0 || totalBytes <= chunkSize) {
     const resp = await fetch(url)
-    if (!resp.ok) throw new Error(`Download failed: ${resp.statusText}`)
-    const blob = await resp.blob()
-    downloadBlob(blob, dispositionFilename)
-    onProgress?.(totalBytes, totalBytes)
+    await downloadFromResponse(resp, dispositionFilename)
     return
   }
 
@@ -96,7 +89,6 @@ export async function downloadChunked(
     const blob = await resp.blob()
     chunks.push(blob)
     downloaded += blob.size
-    onProgress?.(downloaded, totalBytes)
     if (blob.size === 0) break
   }
 
@@ -105,27 +97,20 @@ export async function downloadChunked(
 }
 
 /**
- * Download a file, automatically choosing between a simple fetch and a
- * chunked (Range-request) download based on the configured chunk size.
- *
+ * Download a file, automatically choosing between
+ * a simple fetch and a chunked download based on chunkSize
  * @param url - The API URL to download from
  * @param filename - The filename to save as
  * @param chunkSize - Maximum bytes per request (0 = no chunking)
- * @param onProgress - Optional progress callback
  */
 export async function downloadFile(
   url: string,
   filename: string,
   chunkSize: number,
-  onProgress?: (bytesDownloaded: number, totalBytes: number) => void,
 ): Promise<void> {
   if (chunkSize > 0) {
-    return downloadChunked(url, filename, chunkSize, onProgress)
+    return downloadChunked(url, filename, chunkSize)
   }
   const resp = await fetch(url)
-  if (!resp.ok) throw new Error(`Download failed: ${resp.statusText}`)
-  const blob = await resp.blob()
-  const dispositionFilename = extractFilename(resp, filename)
-  downloadBlob(blob, dispositionFilename)
-  onProgress?.(blob.size, blob.size)
+  await downloadFromResponse(resp, filename)
 }

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -2,6 +2,8 @@
  * Download utilities for handling blob downloads
  */
 
+import { authFetch as fetch } from './api'
+
 /**
  * Extract filename from content-disposition header or fallback to default
  */
@@ -47,4 +49,83 @@ export function downloadBlob(blob: Blob, filename: string): void {
   a.click()
   document.body.removeChild(a)
   window.URL.revokeObjectURL(url)
+}
+
+/**
+ * Download a file using HTTP Range requests, splitting the transfer into
+ * chunks to stay under reverse-proxy size limits.
+ *
+ * @param url - The API URL to download from (e.g. `/api/files/{id}`)
+ * @param filename - The filename to save as
+ * @param chunkSize - Maximum bytes per range request
+ * @param onProgress - Optional callback with (bytesDownloaded, totalBytes)
+ */
+export async function downloadChunked(
+  url: string,
+  filename: string,
+  chunkSize: number,
+  onProgress?: (bytesDownloaded: number, totalBytes: number) => void,
+): Promise<void> {
+  const headResp = await fetch(url, { method: 'HEAD' })
+  if (!headResp.ok) throw new Error(`Download failed: ${headResp.statusText}`)
+
+  const contentLength = headResp.headers.get('content-length')
+  const totalBytes = contentLength ? parseInt(contentLength, 10) : 0
+  const dispositionFilename = extractFilename(headResp, filename)
+
+  if (totalBytes === 0 || totalBytes <= chunkSize) {
+    const resp = await fetch(url)
+    if (!resp.ok) throw new Error(`Download failed: ${resp.statusText}`)
+    const blob = await resp.blob()
+    downloadBlob(blob, dispositionFilename)
+    onProgress?.(totalBytes, totalBytes)
+    return
+  }
+
+  const chunks: Blob[] = []
+  let downloaded = 0
+
+  while (downloaded < totalBytes) {
+    const end = Math.min(downloaded + chunkSize - 1, totalBytes - 1)
+    const resp = await fetch(url, {
+      headers: { Range: `bytes=${downloaded}-${end}` },
+    })
+    if (!resp.ok && resp.status !== 206) {
+      throw new Error(`Chunk download failed: ${resp.statusText}`)
+    }
+    const blob = await resp.blob()
+    chunks.push(blob)
+    downloaded += blob.size
+    onProgress?.(downloaded, totalBytes)
+    if (blob.size === 0) break
+  }
+
+  const finalBlob = new Blob(chunks)
+  downloadBlob(finalBlob, dispositionFilename)
+}
+
+/**
+ * Download a file, automatically choosing between a simple fetch and a
+ * chunked (Range-request) download based on the configured chunk size.
+ *
+ * @param url - The API URL to download from
+ * @param filename - The filename to save as
+ * @param chunkSize - Maximum bytes per request (0 = no chunking)
+ * @param onProgress - Optional progress callback
+ */
+export async function downloadFile(
+  url: string,
+  filename: string,
+  chunkSize: number,
+  onProgress?: (bytesDownloaded: number, totalBytes: number) => void,
+): Promise<void> {
+  if (chunkSize > 0) {
+    return downloadChunked(url, filename, chunkSize, onProgress)
+  }
+  const resp = await fetch(url)
+  if (!resp.ok) throw new Error(`Download failed: ${resp.statusText}`)
+  const blob = await resp.blob()
+  const dispositionFilename = extractFilename(resp, filename)
+  downloadBlob(blob, dispositionFilename)
+  onProgress?.(blob.size, blob.size)
 }


### PR DESCRIPTION
## What

Adds configurable chunked file transfers (disabled by default) to keep individual HTTP requests under reverse-proxy size limits such as Cloudflare's 100 MB file upload limit.

**Configuration:** New `MAX_CHUNK_SIZE` env var. Set to `0` to disable chunking

## Why

Users running Transmute behind Cloudflare tunnels (or similar proxies with per-request size limits) cannot upload or download files larger than the proxy limit. Chunking keeps every individual request within the limit while supporting arbitrarily large files.

## Testing


---

* [x] Tested locally
* [x] Docs updated if needed -> https://github.com/transmute-app/transmute-app.github.io/pull/16