### PR TITLE
feat(api): add optional pagination for files and jobs lists

### DIFF
--- a/backend/api/pagination.py
+++ b/backend/api/pagination.py
@@ -1,0 +1,43 @@
+"""Shared helpers for optional page/page_size list pagination."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def build_pagination_meta(
+    *,
+    total_items: int,
+    page: int,
+    page_size: int,
+) -> dict[str, Any]:
+    """Build the pagination metadata object recommended by issue #179."""
+    total_pages = max(1, math.ceil(total_items / page_size)) if page_size else 1
+    return {
+        "total_items": total_items,
+        "total_pages": total_pages,
+        "current_page": page,
+        "page_size": page_size,
+        "has_next": page < total_pages,
+        "has_prev": page > 1,
+    }
+
+
+def resolve_pagination(
+    page: int | None,
+    page_size: int | None,
+    *,
+    default_page_size: int = 20,
+) -> tuple[int, int, int] | None:
+    """Return ``(page, page_size, offset)`` when pagination is requested.
+
+    Pagination is opt-in: if both ``page`` and ``page_size`` are omitted, return
+    ``None`` so callers keep their existing unpaginated behaviour.
+    """
+    if page is None and page_size is None:
+        return None
+    resolved_page = 1 if page is None else page
+    resolved_size = default_page_size if page_size is None else page_size
+    offset = (resolved_page - 1) * resolved_size
+    return resolved_page, resolved_size, offset

--- a/backend/api/routes/compression_jobs.py
+++ b/backend/api/routes/compression_jobs.py
@@ -4,13 +4,14 @@ These endpoints persist compression requests as durable jobs that a background
 worker processes asynchronously, in contrast with the synchronous
 ``POST /api/compressions`` endpoint which runs the compression inline.
 """
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from api.deps import (
     get_compression_job_db,
     get_current_active_user,
     get_file_db,
 )
+from api.pagination import build_pagination_meta, resolve_pagination
 from api.schemas import (
     CompressionJobCreateRequest,
     CompressionJobListResponse,
@@ -54,12 +55,14 @@ def _serialize_job(job: dict) -> dict:
     responses={
         200: {
             "model": CompressionJobListResponse,
-            "description": "List of compression jobs newest-first",
+            "description": "List of compression jobs newest-first (optionally paginated)",
         }
     },
 )
 def list_jobs(
     status_filter: str | None = None,
+    page: int | None = Query(None, ge=1, description="Page number (1-indexed). Omit with page_size for an unpaginated list."),
+    page_size: int | None = Query(None, ge=1, le=100, description="Items per page (max 100). Omit with page for an unpaginated list."),
     job_db: CompressionJobDB = Depends(get_compression_job_db),
     current_user: dict = Depends(get_current_active_user),
 ):
@@ -67,9 +70,33 @@ def list_jobs(
 
     Optional ``status_filter`` query parameter narrows the result to one of:
     ``queued``, ``running``, ``completed``, ``failed``, ``cancelled``.
+
+    When ``page`` and/or ``page_size`` are provided, results are paginated and
+    a ``pagination`` metadata object is included. Omitting both keeps the
+    legacy unpaginated ``{jobs: [...]}`` response.
     """
-    rows = job_db.list_jobs(user_id=current_user["uuid"], status=status_filter)
-    return {"jobs": [_serialize_job(row) for row in rows]}
+    user_id = current_user["uuid"]
+    paging = resolve_pagination(page, page_size)
+    if paging is None:
+        rows = job_db.list_jobs(user_id=user_id, status=status_filter)
+        return {"jobs": [_serialize_job(row) for row in rows]}
+
+    resolved_page, resolved_size, offset = paging
+    total_items = job_db.count_jobs(user_id=user_id, status=status_filter)
+    rows = job_db.list_jobs(
+        user_id=user_id,
+        status=status_filter,
+        limit=resolved_size,
+        offset=offset,
+    )
+    return {
+        "jobs": [_serialize_job(row) for row in rows],
+        "pagination": build_pagination_meta(
+            total_items=total_items,
+            page=resolved_page,
+            page_size=resolved_size,
+        ),
+    }
 
 
 @router.post(

--- a/backend/api/routes/files.py
+++ b/backend/api/routes/files.py
@@ -4,7 +4,7 @@ import hashlib
 import mimetypes
 import logging
 
-from fastapi import APIRouter, File, UploadFile, HTTPException, Depends, BackgroundTasks
+from fastapi import APIRouter, File, UploadFile, HTTPException, Depends, BackgroundTasks, Query
 from fastapi.responses import FileResponse
 from zipfile import ZipFile
 from pathlib import Path
@@ -12,6 +12,7 @@ from core import get_settings, detect_media_type, sanitize_extension, sanitize_f
 from db import FileDB, ConversionDB, CompressionDB
 from registry import registry as converter_registry
 from api.deps import get_current_active_user, get_file_db, get_conversion_db, get_compression_db
+from api.pagination import build_pagination_meta, resolve_pagination
 from api.schemas import FileListResponse, FileUploadResponse, FileUrlUploadResponse, FileDeleteResponse, ErrorResponse, BatchDownloadRequest, UrlUploadRequest
 from registry import downloader_registry
 from downloaders import DownloadError, YtDlpDownloader
@@ -108,23 +109,47 @@ async def save_file(file: UploadFile, db: FileDB, user_id: str) -> dict:
 
 @router.get(
     "",
-    summary="List all uploaded files",
+    summary="List uploaded files",
     responses={
         200: {
             "model": FileListResponse,
-            "description": "List of all uploaded files"
+            "description": "List of uploaded files (optionally paginated)"
         }
     }
 )
 def list_files(
+    page: int | None = Query(None, ge=1, description="Page number (1-indexed). Omit with page_size for an unpaginated list."),
+    page_size: int | None = Query(None, ge=1, le=100, description="Items per page (max 100). Omit with page for an unpaginated list."),
     file_db: FileDB = Depends(get_file_db),
     current_user: dict = Depends(get_current_active_user),
 ):
-    """List all uploaded files for the current user"""
-    files = file_db.list_files(user_id=current_user["uuid"])
+    """List uploaded files for the current user, newest-first.
+
+    When ``page`` and/or ``page_size`` are provided, results are paginated and
+    a ``pagination`` metadata object is included. Omitting both keeps the
+    legacy unpaginated ``{files: [...]}`` response so existing clients keep working.
+    """
+    user_id = current_user["uuid"]
+    paging = resolve_pagination(page, page_size)
+    if paging is None:
+        files = file_db.list_files(user_id=user_id)
+        for file in files:
+            file["compatible_formats"] = converter_registry.get_compatible_formats_and_qualities(file["media_type"])
+        return {"files": files}
+
+    resolved_page, resolved_size, offset = paging
+    total_items = file_db.count_files(user_id=user_id)
+    files = file_db.list_files(user_id=user_id, limit=resolved_size, offset=offset)
     for file in files:
         file["compatible_formats"] = converter_registry.get_compatible_formats_and_qualities(file["media_type"])
-    return {"files": files}
+    return {
+        "files": files,
+        "pagination": build_pagination_meta(
+            total_items=total_items,
+            page=resolved_page,
+            page_size=resolved_size,
+        ),
+    }
 
 
 @router.post(

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -4,13 +4,14 @@ These endpoints persist conversion requests as durable jobs that a background
 worker processes asynchronously, in contrast with the legacy synchronous
 ``POST /api/conversions`` endpoint which still runs the conversion inline.
 """
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from api.deps import (
     get_conversion_job_db,
     get_current_active_user,
     get_file_db,
 )
+from api.pagination import build_pagination_meta, resolve_pagination
 from api.schemas import (
     ConversionJobCreateRequest,
     ConversionJobListResponse,
@@ -55,12 +56,14 @@ def _serialize_job(job: dict) -> dict:
     responses={
         200: {
             "model": ConversionJobListResponse,
-            "description": "List of conversion jobs newest-first",
+            "description": "List of conversion jobs newest-first (optionally paginated)",
         }
     },
 )
 def list_jobs(
     status_filter: str | None = None,
+    page: int | None = Query(None, ge=1, description="Page number (1-indexed). Omit with page_size for an unpaginated list."),
+    page_size: int | None = Query(None, ge=1, le=100, description="Items per page (max 100). Omit with page for an unpaginated list."),
     job_db: ConversionJobDB = Depends(get_conversion_job_db),
     current_user: dict = Depends(get_current_active_user),
 ):
@@ -68,9 +71,33 @@ def list_jobs(
 
     Optional ``status_filter`` query parameter narrows the result to one of:
     ``queued``, ``running``, ``completed``, ``failed``, ``cancelled``.
+
+    When ``page`` and/or ``page_size`` are provided, results are paginated and
+    a ``pagination`` metadata object is included. Omitting both keeps the
+    legacy unpaginated ``{jobs: [...]}`` response.
     """
-    rows = job_db.list_jobs(user_id=current_user["uuid"], status=status_filter)
-    return {"jobs": [_serialize_job(row) for row in rows]}
+    user_id = current_user["uuid"]
+    paging = resolve_pagination(page, page_size)
+    if paging is None:
+        rows = job_db.list_jobs(user_id=user_id, status=status_filter)
+        return {"jobs": [_serialize_job(row) for row in rows]}
+
+    resolved_page, resolved_size, offset = paging
+    total_items = job_db.count_jobs(user_id=user_id, status=status_filter)
+    rows = job_db.list_jobs(
+        user_id=user_id,
+        status=status_filter,
+        limit=resolved_size,
+        offset=offset,
+    )
+    return {
+        "jobs": [_serialize_job(row) for row in rows],
+        "pagination": build_pagination_meta(
+            total_items=total_items,
+            page=resolved_page,
+            page_size=resolved_size,
+        ),
+    }
 
 
 @router.post(

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -12,6 +12,15 @@ class ConversionRequest(BaseModel):
 ConversionJobStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
 
 
+class PaginationMeta(BaseModel):
+    total_items: int = Field(..., description="Total number of items across all pages", json_schema_extra={"example": 125})
+    total_pages: int = Field(..., description="Total number of pages", json_schema_extra={"example": 13})
+    current_page: int = Field(..., description="Current page number (1-indexed)", json_schema_extra={"example": 1})
+    page_size: int = Field(..., description="Number of items per page", json_schema_extra={"example": 10})
+    has_next: bool = Field(..., description="Whether a next page exists", json_schema_extra={"example": True})
+    has_prev: bool = Field(..., description="Whether a previous page exists", json_schema_extra={"example": False})
+
+
 class ConversionJobCreateRequest(BaseModel):
     id: str = Field(..., description="ID of the source file to convert", json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"})
     output_format: str = Field(..., description="Target format for conversion", json_schema_extra={"example": "png"})
@@ -41,6 +50,7 @@ class ConversionJobResponse(BaseModel):
 
 class ConversionJobListResponse(BaseModel):
     jobs: list[ConversionJobResponse] = Field(..., description="List of conversion jobs for the current user")
+    pagination: Optional[PaginationMeta] = Field(None, description="Present when page/page_size query params are used")
 
 
 class FileMetadata(BaseModel):
@@ -117,6 +127,7 @@ class ReadinessResponse(BaseModel):
 
 class FileListResponse(BaseModel):
     files: list[FileMetadata] = Field(..., description="List of uploaded files")
+    pagination: Optional[PaginationMeta] = Field(None, description="Present when page/page_size query params are used")
 
 
 class UrlUploadRequest(BaseModel):
@@ -259,6 +270,7 @@ class CompressionJobResponse(BaseModel):
 
 class CompressionJobListResponse(BaseModel):
     jobs: list[CompressionJobResponse] = Field(..., description="List of compression jobs for the current user")
+    pagination: Optional[PaginationMeta] = Field(None, description="Present when page/page_size query params are used")
 
 
 class CompressionItem(BaseModel):

--- a/backend/db/file_db.py
+++ b/backend/db/file_db.py
@@ -173,16 +173,56 @@ class FileDB:
             return None
         return self._refresh_pdf_media_type(dict(row))
 
-    def list_files(self, user_id: str | None = None) -> list[dict]:
-        """Retrieve metadata for files, optionally filtered by user."""
+    def list_files(
+        self,
+        user_id: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict]:
+        """Retrieve metadata for files, newest-first, optionally filtered by user.
+
+        Args:
+            user_id: Optional user UUID to filter results.
+            limit: Maximum number of rows to return. ``None`` returns all.
+            offset: Number of rows to skip (used for pagination).
+        """
+        params: list = []
+        where_sql = ""
+        if user_id is not None:
+            where_sql = "WHERE user_id = ?"
+            params.append(user_id)
+        limit_sql = ""
+        if limit is not None:
+            limit_sql = " LIMIT ? OFFSET ?"
+            params.extend([int(limit), int(offset)])
         cursor = self.conn.cursor()
         cursor.row_factory = sqlite3.Row
-        if user_id is not None:
-            cursor.execute(f"SELECT * FROM {self.TABLE_NAME} WHERE user_id = ?", (user_id,))  # nosec B608
-        else:
-            cursor.execute(f"SELECT * FROM {self.TABLE_NAME}")  # nosec B608
+        cursor.execute(  # nosec B608
+            f"SELECT * FROM {self.TABLE_NAME} {where_sql} ORDER BY created_at DESC, rowid DESC{limit_sql}",
+            tuple(params),
+        )
         rows = cursor.fetchall()
         return [self._refresh_pdf_media_type(dict(row)) for row in rows]
+
+    def count_files(self, user_id: str | None = None) -> int:
+        """Count files, optionally filtered by user.
+
+        Args:
+            user_id: Optional user UUID to filter results.
+
+        Returns:
+            Total number of matching file rows.
+        """
+        cursor = self.conn.cursor()
+        if user_id is not None:
+            cursor.execute(  # nosec B608
+                f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE user_id = ?",
+                (user_id,),
+            )
+        else:
+            cursor.execute(f"SELECT COUNT(*) FROM {self.TABLE_NAME}")  # nosec B608
+        row = cursor.fetchone()
+        return int(row[0]) if row is not None else 0
 
     def delete_file_metadata(self, file_id: str) -> None:
         """Delete the metadata record for a specific file.

--- a/backend/tests/api/test_pagination.py
+++ b/backend/tests/api/test_pagination.py
@@ -1,0 +1,32 @@
+"""Unit tests for optional list pagination helpers."""
+
+from api.pagination import build_pagination_meta, resolve_pagination
+
+
+def test_resolve_pagination_omitted_keeps_legacy_behaviour():
+    assert resolve_pagination(None, None) is None
+
+
+def test_resolve_pagination_defaults_missing_fields():
+    assert resolve_pagination(2, None) == (2, 20, 20)
+    assert resolve_pagination(None, 10) == (1, 10, 0)
+    assert resolve_pagination(3, 5) == (3, 5, 10)
+
+
+def test_build_pagination_meta_flags():
+    meta = build_pagination_meta(total_items=25, page=2, page_size=10)
+    assert meta == {
+        "total_items": 25,
+        "total_pages": 3,
+        "current_page": 2,
+        "page_size": 10,
+        "has_next": True,
+        "has_prev": True,
+    }
+
+
+def test_build_pagination_meta_empty_collection():
+    meta = build_pagination_meta(total_items=0, page=1, page_size=20)
+    assert meta["total_pages"] == 1
+    assert meta["has_next"] is False
+    assert meta["has_prev"] is False

--- a/backend/tests/core/test_conversion_job_db.py
+++ b/backend/tests/core/test_conversion_job_db.py
@@ -100,6 +100,17 @@ def test_count_jobs_filters_by_user_and_status(job_db):
     assert job_db.count_jobs(status="queued") == 2
 
 
+def test_list_jobs_supports_limit_and_offset(job_db):
+    for i in range(5):
+        job_db.insert_job(_make_job(user_id="user-a", source_id=f"f{i}"))
+
+    page = job_db.list_jobs(user_id="user-a", limit=2, offset=0)
+    assert len(page) == 2
+    page2 = job_db.list_jobs(user_id="user-a", limit=2, offset=2)
+    assert len(page2) == 2
+    assert {j["id"] for j in page}.isdisjoint({j["id"] for j in page2})
+
+
 def test_claim_next_queued_job_marks_running(job_db):
     job1 = job_db.insert_job(_make_job(source_id="f1"))
     job2 = job_db.insert_job(_make_job(source_id="f2"))


### PR DESCRIPTION
## What
Adds optional `page` / `page_size` query params to `GET /api/files`, `GET /api/jobs`, and `GET /api/compression-jobs`. When provided, responses keep the existing `files`/`jobs` keys and add pagination metadata. Omitting both params preserves the legacy full-list response.

## Why
Files and jobs lists currently return every row; server-side pagination is needed for scale (Fixes #179). This backend slice is backward-compatible so the current frontend keeps working until UI pagination lands.

## Testing
- Unit tests for pagination helpers and job DB limit/offset
- Manual: `GET /api/files` unchanged without params; with `?page=1&page_size=2` returns a page plus pagination meta

---

* [x] Tested locally
* [ ] Docs updated if needed