### PR TITLE
feat(auth): authenticate via configurable HTTP headers

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -7,6 +7,7 @@ from fastapi.security import OAuth2PasswordBearer
 from jwt import InvalidTokenError
 
 from core.auth import decode_access_token, verify_password
+from core.header_auth import resolve_user_from_headers
 from db import FileDB, ConversionDB, ConversionRelationsDB, ConversionJobDB, CompressionDB, CompressionRelationsDB, CompressionJobDB, SettingsDB, DefaultFormatsDB, DefaultQualitiesDB, DefaultCompressionLevelsDB, UserDB, ApiKeyDB, UserIdentityDB
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/users/token")
@@ -114,60 +115,63 @@ def _resolve_user_from_api_key(raw_key: str, api_key_db: ApiKeyDB, user_db: User
     return None
 
 
+def _resolve_user_from_bearer(
+    token: str,
+    user_db: UserDB,
+    api_key_db: ApiKeyDB,
+) -> dict | None:
+    """Resolve a user from a JWT or API key bearer token."""
+    try:
+        payload = decode_access_token(token)
+        subject = payload.get("sub")
+        if isinstance(subject, str) and subject:
+            user = user_db.get_user(subject)
+            if user is not None:
+                return user
+    except InvalidTokenError:
+        logger.debug("Token is not a valid JWT, attempting API key resolution")
+
+    return _resolve_user_from_api_key(token, api_key_db, user_db)
+
+
 def get_current_user(
     request: Request,
-    token: str = Depends(oauth2_scheme),
+    token: str | None = Depends(oauth2_scheme_optional),
     user_db: UserDB = Depends(get_user_db),
     api_key_db: ApiKeyDB = Depends(get_api_key_db),
 ) -> dict:
-    """Resolve the current user from a bearer token (JWT or API key)."""
+    """Resolve the current user from a bearer token or trusted identity headers."""
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    # Try JWT first
-    try:
-        payload = decode_access_token(token)
-        subject = payload.get("sub")
-        if isinstance(subject, str) and subject:
-            user = user_db.get_user(subject)
-            if user is not None:
-                return user
-    except InvalidTokenError:
-        logger.debug("Token is not a valid JWT, attempting API key resolution")
+    if token:
+        user = _resolve_user_from_bearer(token, user_db, api_key_db)
+        if user is not None:
+            return user
 
-    # Fall back to API key
-    user = _resolve_user_from_api_key(token, api_key_db, user_db)
-    if user is not None:
-        return user
+    header_user = resolve_user_from_headers(request, user_db)
+    if header_user is not None:
+        return header_user
 
     raise credentials_exception
 
 
 def get_current_user_optional(
+    request: Request,
     token: str | None = Depends(oauth2_scheme_optional),
     user_db: UserDB = Depends(get_user_db),
     api_key_db: ApiKeyDB = Depends(get_api_key_db),
 ) -> dict | None:
-    """Best-effort bearer token resolution for bootstrap-aware routes."""
-    if not token:
-        return None
+    """Best-effort auth resolution for bootstrap-aware routes."""
+    if token:
+        user = _resolve_user_from_bearer(token, user_db, api_key_db)
+        if user is not None:
+            return user
 
-    # Try JWT first
-    try:
-        payload = decode_access_token(token)
-        subject = payload.get("sub")
-        if isinstance(subject, str) and subject:
-            user = user_db.get_user(subject)
-            if user is not None:
-                return user
-    except InvalidTokenError:
-        logger.debug("Token is not a valid JWT, attempting API key resolution")
-
-    # Fall back to API key
-    return _resolve_user_from_api_key(token, api_key_db, user_db)
+    return resolve_user_from_headers(request, user_db)
 
 
 def get_current_active_user(current_user: dict = Depends(get_current_user)) -> dict:

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -1,7 +1,7 @@
 import sqlite3
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from api.deps import (
@@ -23,11 +23,16 @@ from api.schemas import (
 )
 from core import delete_file_and_metadata
 from core.auth import create_access_token, get_password_hash_str, verify_password
+from core.header_auth import header_auth_enabled, resolve_user_from_headers
 from db import UserDB, ApiKeyDB, FileDB, ConversionDB, ConversionRelationsDB, SettingsDB, DefaultFormatsDB
 
 router = APIRouter(prefix="/users", tags=["users"])
 
-_UNUSABLE_PASSWORDS = frozenset({"!oidc-no-password", "!guest-no-password"})
+_UNUSABLE_PASSWORDS = frozenset({
+    "!oidc-no-password",
+    "!guest-no-password",
+    "!header-auth-no-password",
+})
 
 
 @router.get(
@@ -210,6 +215,38 @@ def authenticate_user(
         raise HTTPException(status_code=401, detail="Invalid username or password")
     if user["disabled"]:
         raise HTTPException(status_code=403, detail="User account is disabled")
+    return _build_auth_response(user)
+
+
+@router.post(
+    "/header-authenticate",
+    summary="Authenticate via trusted HTTP identity headers",
+    responses={
+        200: {
+            "model": UserAuthResponse,
+            "description": "Authentication succeeded",
+        },
+        401: {
+            "model": ErrorResponse,
+            "description": "Header auth disabled, missing headers, or unknown user",
+        },
+        403: {
+            "model": ErrorResponse,
+            "description": "User account is disabled",
+        },
+    },
+)
+def header_authenticate(
+    request: Request,
+    db: UserDB = Depends(get_user_db),
+):
+    """Issue a JWT from reverse-proxy identity headers (oauth2-proxy style)."""
+    if not header_auth_enabled():
+        raise HTTPException(status_code=401, detail="Header authentication is disabled")
+
+    user = resolve_user_from_headers(request, db)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Missing identity headers")
     return _build_auth_response(user)
 
 

--- a/backend/core/README.md
+++ b/backend/core/README.md
@@ -13,9 +13,22 @@ This package contains backend-wide utilities, configuration, and shared applicat
 - `settings.py`: application configuration and derived runtime paths.
 - `logging.py`: central logging setup based on uvicorn's default log configuration.
 - `auth.py`: token and password-related auth helpers.
+- `header_auth.py`: reverse-proxy HTTP header identity helpers (oauth2-proxy style).
 - `media_types.py`: alias mapping and normalization support for media types.
 - `helper_functions.py`: shared filesystem, validation, hashing, and cleanup helpers.
 - `__init__.py`: curated exports for commonly used core utilities.
+
+## Header auth environment variables
+
+Enable only behind a trusted reverse proxy that sets (and strips client-supplied) identity headers:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HEADER_AUTH_ENABLED` | `false` | Accept identity from HTTP headers |
+| `HEADER_AUTH_USERNAME_HEADER` | `X-Forwarded-User` | Header carrying the username |
+| `HEADER_AUTH_EMAIL_HEADER` | `X-Forwarded-Email` | Optional email header |
+| `HEADER_AUTH_AUTO_CREATE` | `false` | Auto-provision unknown users |
+| `ALLOW_PUBLIC_SIGNUP` | `false` | Also enables header auto-create when true |
 
 ## How To Work In This Folder
 

--- a/backend/core/header_auth.py
+++ b/backend/core/header_auth.py
@@ -1,0 +1,85 @@
+"""HTTP header-based authentication helpers (oauth2-proxy and similar)."""
+from __future__ import annotations
+
+import re
+import uuid
+
+from fastapi import HTTPException, Request
+
+from core.settings import get_settings
+from db import UserDB, UserRole
+
+_UNUSABLE_PASSWORD = "!header-auth-no-password"
+_USERNAME_SAFE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+def header_auth_enabled() -> bool:
+    return bool(get_settings().header_auth_enabled)
+
+
+def _header_value(request: Request, header_name: str) -> str | None:
+    if not header_name:
+        return None
+    value = request.headers.get(header_name)
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _sanitize_username(raw: str) -> str:
+    cleaned = _USERNAME_SAFE.sub(".", raw.strip())
+    cleaned = cleaned.strip(".")
+    return cleaned or "user"
+
+
+def _unique_username(user_db: UserDB, base: str) -> str:
+    candidate = _sanitize_username(base)
+    if not user_db.username_exists(candidate):
+        return candidate
+    for index in range(2, 1000):
+        next_candidate = f"{candidate}-{index}"
+        if not user_db.username_exists(next_candidate):
+            return next_candidate
+    raise HTTPException(status_code=500, detail="Unable to allocate a unique username")
+
+
+def resolve_user_from_headers(request: Request, user_db: UserDB) -> dict | None:
+    """Resolve or provision a user from trusted reverse-proxy headers."""
+    settings = get_settings()
+    if not settings.header_auth_enabled:
+        return None
+
+    username = _header_value(request, settings.header_auth_username_header)
+    if not username:
+        return None
+
+    email = _header_value(request, settings.header_auth_email_header)
+    user = user_db.get_user_by_username(username)
+    if user is None and email:
+        user = user_db.get_user_by_email(email)
+
+    if user is not None:
+        if user.get("disabled"):
+            raise HTTPException(status_code=403, detail="User account is disabled")
+        return user
+
+    can_auto_create = bool(settings.header_auth_auto_create or settings.allow_public_signup)
+    if not can_auto_create:
+        raise HTTPException(
+            status_code=401,
+            detail="Header authentication user does not exist and auto-create is disabled",
+        )
+
+    # Mirror bootstrap: first non-guest user becomes admin; later header users are members.
+    role = UserRole.ADMIN.value if not user_db.has_non_guest_users() else UserRole.MEMBER.value
+    created = user_db.insert_user({
+        "uuid": str(uuid.uuid4()),
+        "username": _unique_username(user_db, username),
+        "email": email,
+        "full_name": username,
+        "hashed_password": _UNUSABLE_PASSWORD,
+        "role": role,
+        "disabled": False,
+    })
+    return created

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -92,6 +92,21 @@ class Settings(BaseSettings):
     # ===== Guest Access =====
     allow_unauthenticated: bool = False
 
+    # When True, unauthenticated callers may create standard (member) accounts
+    # after the initial admin bootstrap is complete (see #244). Also enables
+    # header-auth auto-provisioning when HEADER_AUTH_AUTO_CREATE is false.
+    allow_public_signup: bool = False
+
+    # ===== Header auth (oauth2-proxy and similar reverse proxies) =====
+    # Trust identity headers only when Transmute sits behind a proxy that
+    # strips/overwrites these headers from untrusted clients.
+    header_auth_enabled: bool = False
+    header_auth_username_header: str = "X-Forwarded-User"
+    header_auth_email_header: str = "X-Forwarded-Email"
+    # When True (or allow_public_signup is True), unknown header identities
+    # are auto-provisioned as local users.
+    header_auth_auto_create: bool = False
+
     # ===== Server =====
 
     # http://192.168.1.1:3313

--- a/backend/tests/api/test_header_auth.py
+++ b/backend/tests/api/test_header_auth.py
@@ -1,0 +1,122 @@
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+
+def _ensure_optional_native_stubs():
+    """Allow importing the app without WeasyPrint system libraries (Windows CI/dev)."""
+    if "weasyprint" not in sys.modules:
+        stub = types.ModuleType("weasyprint")
+        stub.HTML = object
+        sys.modules["weasyprint"] = stub
+
+
+def _make_client(monkeypatch, tmp_path, **env):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("AUTH_SECRET_KEY", "test-secret-key")
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    _ensure_optional_native_stubs()
+
+    from core.settings import get_settings
+    get_settings.cache_clear()
+
+    import main
+    from api import deps
+
+    deps._user_db.cache_clear()
+    deps._file_db.cache_clear()
+    deps._settings_db.cache_clear()
+
+    return TestClient(main.create_app())
+
+
+def test_header_authenticate_auto_creates_user(monkeypatch, tmp_path):
+    client = _make_client(
+        monkeypatch,
+        tmp_path,
+        HEADER_AUTH_ENABLED="true",
+        HEADER_AUTH_AUTO_CREATE="true",
+    )
+
+    response = client.post(
+        "/api/users/header-authenticate",
+        headers={
+            "X-Forwarded-User": "alice",
+            "X-Forwarded-Email": "alice@example.com",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user"]["username"] == "alice"
+    assert body["user"]["email"] == "alice@example.com"
+    assert body["user"]["role"] == "admin"
+    assert body["token_type"] == "bearer"
+    assert body["access_token"]
+    assert body["expires_in"] > 0
+
+
+def test_header_auth_protects_me_endpoint(monkeypatch, tmp_path):
+    client = _make_client(
+        monkeypatch,
+        tmp_path,
+        HEADER_AUTH_ENABLED="true",
+        HEADER_AUTH_AUTO_CREATE="true",
+    )
+
+    me = client.get(
+        "/api/users/me",
+        headers={"X-Forwarded-User": "bob"},
+    )
+    assert me.status_code == 200
+    assert me.json()["username"] == "bob"
+
+
+def test_header_authenticate_disabled_returns_401(monkeypatch, tmp_path):
+    client = _make_client(monkeypatch, tmp_path, HEADER_AUTH_ENABLED="false")
+
+    response = client.post(
+        "/api/users/header-authenticate",
+        headers={"X-Forwarded-User": "alice"},
+    )
+    assert response.status_code == 401
+
+
+def test_header_auth_custom_headers_and_public_signup(monkeypatch, tmp_path):
+    client = _make_client(
+        monkeypatch,
+        tmp_path,
+        HEADER_AUTH_ENABLED="true",
+        HEADER_AUTH_AUTO_CREATE="false",
+        ALLOW_PUBLIC_SIGNUP="true",
+        HEADER_AUTH_USERNAME_HEADER="X-Auth-User",
+        HEADER_AUTH_EMAIL_HEADER="X-Auth-Email",
+    )
+
+    response = client.post(
+        "/api/users/header-authenticate",
+        headers={
+            "X-Auth-User": "carol",
+            "X-Auth-Email": "carol@example.com",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["user"]["username"] == "carol"
+
+
+def test_header_auth_rejects_unknown_user_without_auto_create(monkeypatch, tmp_path):
+    client = _make_client(
+        monkeypatch,
+        tmp_path,
+        HEADER_AUTH_ENABLED="true",
+        HEADER_AUTH_AUTO_CREATE="false",
+        ALLOW_PUBLIC_SIGNUP="false",
+    )
+
+    response = client.post(
+        "/api/users/header-authenticate",
+        headers={"X-Forwarded-User": "nobody"},
+    )
+    assert response.status_code == 401

--- a/k8s-deployment.yml
+++ b/k8s-deployment.yml
@@ -77,6 +77,16 @@ spec:
             # also change the Ingress "path" below from "/" to "/transmute".
             - name: APP_URL
               value: "https://transmute.your-domain.example"
+            # Optional: trust oauth2-proxy (or similar) identity headers.
+            # Only enable when the ingress/proxy strips these headers from clients.
+            # - name: HEADER_AUTH_ENABLED
+            #   value: "true"
+            # - name: HEADER_AUTH_USERNAME_HEADER
+            #   value: "X-Forwarded-User"
+            # - name: HEADER_AUTH_EMAIL_HEADER
+            #   value: "X-Forwarded-Email"
+            # - name: HEADER_AUTH_AUTO_CREATE
+            #   value: "true"
           ports:
             - name: http
               containerPort: 3313


### PR DESCRIPTION
## What
Add oauth2-proxy-style HTTP header authentication with configurable username/email headers, optional auto-provisioning, and `POST /api/users/header-authenticate`.

## Why
Enables SSO deployments that inject trusted identity headers (see #245). Auto-create follows `HEADER_AUTH_AUTO_CREATE` or `ALLOW_PUBLIC_SIGNUP` (#244).

## Testing
- `pytest backend/tests/api/test_header_auth.py` (5 passed)
- Manual: enable `HEADER_AUTH_ENABLED` + `HEADER_AUTH_AUTO_CREATE`, call `/api/users/header-authenticate` and `/api/users/me` with `X-Forwarded-User` / `X-Forwarded-Email`

---

* [x] Tested locally
* [x] Docs updated if needed